### PR TITLE
New implementation for LJPEG92

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.52.0, 1.51.0]
+        rust: [nightly, beta, stable, 1.53.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/rawler/Cargo.toml
+++ b/rawler/Cargo.toml
@@ -8,6 +8,10 @@ version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# This is a developer feature, it enabled deep inspection of algorithm execution stages
+inspector = []
+
 [dependencies]
 bitstream-io = "1.0.0"
 byteorder = "1"

--- a/rawler/Cargo.toml
+++ b/rawler/Cargo.toml
@@ -26,6 +26,7 @@ md5 = "0.7.0"
 rayon = "1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
+simple_logger = "1.11.0"
 thiserror = "1.0.25"
 toml = "0.5"
 uuid = {version = "0.8", features = ["serde", "v4"]}

--- a/rawler/src/bitarray.rs
+++ b/rawler/src/bitarray.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: LGPL-2.1
+// Copyright 2021 Daniel Vogelbacher <daniel@chaospixel.com>
+
+use std::{
+  cmp::Ordering,
+  fmt::{Debug, Display, Write},
+  ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Not, Shl, ShlAssign, Shr, ShrAssign, Sub},
+};
+
+pub type BitArray8 = BitArray<u8>;
+pub type BitArray16 = BitArray<u16>;
+pub type BitArray32 = BitArray<u32>;
+pub type BitArray64 = BitArray<u64>;
+pub type BitArray128 = BitArray<u128>;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BitArray<T: BitStorage> {
+  storage: T,
+  nbits: usize,
+}
+
+impl<T: BitStorage> PartialEq for BitArray<T> {
+  fn eq(&self, other: &Self) -> bool {
+    self.nbits == other.nbits && self.storage == other.storage
+  }
+}
+
+impl<T: BitStorage> Eq for BitArray<T> {}
+
+impl<T: BitStorage> PartialOrd for BitArray<T> {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl<T: BitStorage> Ord for BitArray<T> {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    if self.nbits > other.nbits {
+      Ordering::Greater
+    } else if self.nbits < other.nbits {
+      Ordering::Less
+    } else {
+      self.storage.cmp(&other.storage)
+    }
+  }
+}
+
+impl<T: BitStorage> Display for BitArray<T> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut value = self.clone();
+    let mut str = String::new();
+    while !value.is_empty() {
+      match value.pop() {
+        true => str.push('1'),
+        false => str.push('0'),
+      }
+    }
+    for c in str.chars().rev() {
+      f.write_char(c)?;
+    }
+    Ok(())
+  }
+}
+
+impl<T: BitStorage> BitArray<T> {
+  pub fn new() -> Self {
+    Self {
+      storage: T::default(),
+      nbits: 0,
+    }
+  }
+
+  pub fn len(&self) -> usize {
+    self.nbits
+  }
+
+  pub fn storage(&self) -> T {
+    self.storage
+  }
+
+  pub fn is_full(&self) -> bool {
+    self.nbits == T::bit_size()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.nbits == 0
+  }
+
+  pub fn push(&mut self, bit: bool) {
+    if self.is_full() {
+      panic!("BitArray is full");
+    } else {
+      self.nbits += 1;
+      self.storage = self.storage | T::from(bit) << (T::bit_size() - self.nbits);
+    }
+  }
+
+  pub fn pop(&mut self) -> bool {
+    if self.is_empty() {
+      panic!("BitArray is empty");
+    } else {
+      let mask = T::from(true) << (T::bit_size() - self.nbits);
+      let bit = self.storage & mask;
+      self.storage = self.storage & !mask;
+      self.nbits -= 1;
+      !(bit == T::from(false))
+    }
+  }
+
+  pub fn get_msb(&self) -> T {
+    self.storage
+  }
+
+  pub fn get_lsb(&self) -> T {
+    self.storage >> (T::bit_size() - self.nbits)
+  }
+
+  pub fn from_msb(nbits: usize, value: T) -> Self {
+    Self { storage: value, nbits }
+  }
+
+  pub fn from_lsb(nbits: usize, value: T) -> Self {
+    Self {
+      storage: value << (T::bit_size() - nbits),
+      nbits,
+    }
+  }
+}
+
+pub trait BitStorage:
+  Default
+  + Debug
+  + Display
+  + Copy
+  + Clone
+  + ShlAssign
+  + ShrAssign
+  + Shl<usize>
+  + Shl<usize, Output = Self>
+  + Shr<usize>
+  + Shr<usize, Output = Self>
+  + Add
+  + Sub
+  + Div
+  + Mul
+  + BitXor<Self, Output = Self>
+  + BitOr<Self, Output = Self>
+  + BitAnd<Self, Output = Self>
+  + Not<Output = Self>
+  + PartialEq
+  + From<bool>
+  + Ord
+  + PartialOrd
+  + Eq
+  + PartialEq
+{
+  fn bit_size() -> usize;
+}
+
+impl BitStorage for u8 {
+  fn bit_size() -> usize {
+    Self::BITS as usize
+  }
+}
+impl BitStorage for u16 {
+  fn bit_size() -> usize {
+    Self::BITS as usize
+  }
+}
+impl BitStorage for u32 {
+  fn bit_size() -> usize {
+    Self::BITS as usize
+  }
+}
+impl BitStorage for u64 {
+  fn bit_size() -> usize {
+    Self::BITS as usize
+  }
+}
+impl BitStorage for u128 {
+  fn bit_size() -> usize {
+    Self::BITS as usize
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use simple_logger::SimpleLogger;
+
+  use super::*;
+
+  #[test]
+  fn check_storage() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    assert_eq!(BitArray16::from_lsb(3, 0b110).storage(), 0b1100_0000_0000_0000);
+    assert_eq!(BitArray16::from_msb(3, 0b110 << u16::BITS - 3).storage(), 0b1100_0000_0000_0000);
+    Ok(())
+  }
+
+  #[test]
+  fn push_check_storage() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    let mut bits = BitArray8::new();
+    bits.push(true);
+    assert_eq!(bits.len(), 1);
+    assert_eq!(bits.storage(), 0b1000_0000);
+    Ok(())
+  }
+
+  #[test]
+  fn ppo_check_storage() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    let mut bits = BitArray8::new();
+    bits.push(true);
+    bits.push(false);
+    bits.push(true);
+    assert_eq!(bits.len(), 3);
+    assert_eq!(bits.storage(), 0b1010_0000);
+    assert_eq!(bits.pop(), true);
+    assert_eq!(bits.storage(), 0b1000_0000);
+    assert_eq!(bits.pop(), false);
+    assert_eq!(bits.storage(), 0b1000_0000);
+    assert_eq!(bits.pop(), true);
+    assert_eq!(bits.storage(), 0b0000_0000);
+    assert!(bits.is_empty());
+    Ok(())
+  }
+
+  #[test]
+  fn bitvec_compare() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    assert!(BitArray8::from_lsb(1, 0b1) > BitArray8::from_lsb(1, 0b0));
+    assert!(BitArray8::from_lsb(2, 0b00) > BitArray8::from_lsb(1, 0b0));
+    assert!(BitArray8::from_lsb(2, 0b11) < BitArray8::from_lsb(3, 0b000));
+    assert!(BitArray8::from_lsb(3, 0b101) == BitArray8::from_lsb(3, 0b101));
+    assert!(BitArray8::from_lsb(3, 0b101) != BitArray8::from_lsb(3, 0b111));
+
+    assert_eq!(10u8.cmp(&20u8), Ordering::Less);
+    assert_eq!(BitArray8::from_lsb(1, 0b0).cmp(&BitArray8::from_lsb(1, 0b1)), Ordering::Less);
+    assert_eq!(BitArray8::from_lsb(1, 0b1).cmp(&BitArray8::from_lsb(1, 0b0)), Ordering::Greater);
+    assert_eq!(BitArray8::from_lsb(1, 0b1).cmp(&BitArray8::from_lsb(1, 0b1)), Ordering::Equal);
+    assert_eq!(BitArray8::from_lsb(1, 0b0).cmp(&BitArray8::from_lsb(2, 0b1)), Ordering::Less);
+    assert_eq!(BitArray8::from_lsb(1, 0b1).cmp(&BitArray8::from_lsb(2, 0b0)), Ordering::Less);
+    assert_eq!(BitArray8::from_lsb(1, 0b1).cmp(&BitArray8::from_lsb(2, 0b1)), Ordering::Less);
+    Ok(())
+  }
+}

--- a/rawler/src/devtools/inspector.rs
+++ b/rawler/src/devtools/inspector.rs
@@ -1,0 +1,13 @@
+  // The debug version
+  #[cfg(feature = "inspector")]
+  #[macro_export]
+  macro_rules! inspector {
+      ($( $args:expr ),*) => { println!( $( $args ),* ); }
+  }
+
+  // Non-debug version
+  #[cfg(not(feature = "inspector"))]
+  #[macro_export]
+  macro_rules! inspector {
+      ($( $args:expr ),*) => {}
+  }

--- a/rawler/src/devtools/mod.rs
+++ b/rawler/src/devtools/mod.rs
@@ -1,9 +1,26 @@
 // SPDX-License-Identifier: LGPL-2.1
 // Copyright 2021 Daniel Vogelbacher <daniel@chaospixel.com>
 
+use std::{fs::File, io::{BufWriter, Write}};
+
+use byteorder::{LittleEndian, WriteBytesExt};
 use image::{ImageBuffer, ImageFormat, Luma};
 
 pub fn dump_image_u16(data: &Vec<u16>, width: usize, height: usize, path: impl AsRef<str>) {
   let img = ImageBuffer::<Luma<u16>, Vec<u16>>::from_vec(width as u32, height as u32, data.clone()).unwrap();
   img.save_with_format(path.as_ref(), ImageFormat::Tiff).unwrap();
+}
+
+pub fn dump_buf<T>(path: &str, buf: T) where T: AsRef<[u8]> {
+  let mut f = BufWriter::new(File::create(path).expect("Unable to create file"));
+  f.write_all(buf.as_ref()).expect("Failed to dump buffer to file");
+  f.flush().expect("Failed to flush file");
+}
+
+pub fn dump_buf_u16<T>(path: &str, buf: T) where T: AsRef<[u16]> {
+  let mut f = BufWriter::new(File::create(path).expect("Unable to create file"));
+  for v in buf.as_ref().iter() {
+    f.write_u16::<LittleEndian>(*v).expect("Failed to dump buffer to file");
+  }
+  f.flush().expect("Failed to flush file");
 }

--- a/rawler/src/devtools/mod.rs
+++ b/rawler/src/devtools/mod.rs
@@ -5,6 +5,7 @@ use std::{fs::File, io::{BufWriter, Write}};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use image::{ImageBuffer, ImageFormat, Luma};
+pub(crate) mod inspector;
 
 pub fn dump_image_u16(data: &Vec<u16>, width: usize, height: usize, path: impl AsRef<str>) {
   let img = ImageBuffer::<Luma<u16>, Vec<u16>>::from_vec(width as u32, height as u32, data.clone()).unwrap();

--- a/rawler/src/lib.rs
+++ b/rawler/src/lib.rs
@@ -61,6 +61,7 @@ use lazy_static::lazy_static;
   pub mod cfa;
   pub mod rawimage;
   pub mod ljpeg92;
+  pub mod bitarray;
   pub mod tiff;
   pub mod devtools;
   pub mod dng;

--- a/rawler/src/ljpeg92.rs
+++ b/rawler/src/ljpeg92.rs
@@ -25,10 +25,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::io::Cursor;
-use log::debug;
 use byteorder::{BigEndian, WriteBytesExt};
+use std::{
+  cmp::min,
+  io::{Cursor, Write},
+};
 use thiserror::Error;
+
+use crate::{bitarray::BitArray16, inspector};
 
 /// Error variants for compressor
 #[derive(Debug, Error)]
@@ -58,30 +62,417 @@ pub struct LjpegCompressor<'a> {
   /// height of input image
   height: usize,
   /// Number of components (1-4, only 1 is supported)
-  components: u8,
+  components: usize,
   /// Bitdepth of input image
   bitdepth: u8,
   /// Maximum value for given bit depth
   max_value: u16,
+  /// Point transformation parameter
+  /// **Warning:** This is untested, use with caution
+  point_transform: u8,
+  /// Predictor
+  predictor: u8,
   /// Skip bytes after each line before next line starts
   skip_len: usize,
-  /// Storage for encoded data
-  encoded: Cursor<Vec<u8>>,
-  /// SSSS frequency histogram
-  hist: [usize; 17],
-  bits: [u8; 17], // decoder uses u32?
-  huffval: [u8; 17], // decoder uses u32?
-  huffenc: [u16; 17],
-  huffbits: [u16; 17],
-  huffsym: [usize; 17],
+  /// Component state (histogram, hufftable)
+  comp_state: Vec<ComponentState>,
+}
+
+/// HUFFENC and HUFFBITS
+#[derive(Debug, Default, Clone)]
+struct HuffCode {
+  enc: u16,
+  bits: u16,
+}
+
+/// Huffman table builder
+///
+/// Builds an optimal Huffman table for encoding for a given
+/// list of frequencies and total resolution.
+#[derive(Default, Debug)]
+struct HuffTableBuilder {
+  /// Frequency of occurrence of symbol V
+  /// Used while building the table. Initialized with the
+  /// frequencies for each ssss (0-16).
+  /// Reserving one code point guarantees that no code word can ever be all “1” bits.
+  freq: [f32; Self::CLASSES + 1],
+
+  /// Code size of symbol V
+  /// Size (in bits) for each ssss.
+  codesize: [usize; Self::CLASSES + 1],
+
+  /// Index to next symbol in chain of all symbols in current branch of code tree
+  /// Other frequencies, used during table buildup.
+  others: [Option<usize>; Self::CLASSES + 1],
+
+  /// Numbers of codes of each size
+  bits: Vec<u8>,
+
+  /// List of values (ssss) sorted in ascending
+  /// code length.
+  /// Unused values (at the end of array) are set
+  /// to `None`.
+  huffval: [Option<u8>; Self::CLASSES],
+
+  /// Code for each symbol
+  /// Is is a combination of Huffbits and Huffenc
+  huffcode: [HuffCode; Self::CLASSES],
+
+  /// Maps a value (ssss) to a symbol.
+  /// This symbol can be used as index into
+  /// `huffcode` to get the actual code for encoding.
+  huffsym: [Option<usize>; Self::CLASSES],
+}
+
+impl HuffTableBuilder {
+  /// Count of classes for Lossless JPEG
+  /// For regular JPEG, V goes from 0 to 256. For lossless,
+  /// we only have 17 classes for ssss (0-16).
+  const CLASSES: usize = 17; // Sample classes for Lossless JPEG
+
+  /// Construct new Huffman table for given histogram
+  /// and image resolution
+  fn new(histogram: [usize; Self::CLASSES], resolution: f32) -> Self {
+    let mut ins = Self::default();
+    ins.bits.resize(33, 0);
+    for (i, freq) in histogram.iter().map(|f| *f as f32 / resolution).enumerate() {
+      ins.freq[i] = freq;
+    }
+    //  Last freq must be 1
+    ins.freq[Self::CLASSES] = 1.0;
+    ins
+  }
+
+  /// Figure K.1 - Procedure to find Huffman code sizes
+  fn gen_codesizes(&mut self) {
+    loop {
+      // smallest frequencies found in llop
+      let mut v1freq: f32 = 3.0; // just a value larger then 1.0
+      let mut v2freq: f32 = 3.0;
+      // Indices into frequency table
+      let mut v1: Option<usize> = None;
+      let mut v2: Option<usize> = None;
+      // Search v1
+      for (i, f) in self.freq.iter().enumerate().filter(|(_i, f)| **f > 0.0) {
+        if *f <= v1freq {
+          v1freq = *f;
+          v1 = Some(i);
+        }
+      }
+      // Search v2
+      for (i, f) in self.freq.iter().enumerate().filter(|(i, f)| **f > 0.0 && Some(*i) != v1) {
+        if *f <= v2freq {
+          v2freq = *f;
+          v2 = Some(i);
+        }
+      }
+
+      match (&mut v1, &mut v2) {
+        (Some(v1), Some(v2)) => {
+          // Combine frequency values
+          self.freq[*v1] += self.freq[*v2];
+          self.freq[*v2] = 0.0;
+
+          // Increment code sizes for all codewords in this tree branch
+          loop {
+            self.codesize[*v1] += 1;
+            if let Some(other) = self.others[*v1] {
+              *v1 = other
+            } else {
+              break;
+            }
+          }
+          self.others[*v1] = Some(*v2);
+          loop {
+            self.codesize[*v2] += 1;
+            if let Some(other) = self.others[*v2] {
+              *v2 = other;
+            } else {
+              break;
+            }
+          }
+        }
+        _ => {
+          // exit loop, all frequencies are processed
+          break;
+        }
+      }
+    }
+
+    #[cfg(feature = "inspector")]
+    for (i, codesize) in self.codesize.iter().enumerate() {
+      inspector!("codesize[{}]={}", i, codesize);
+    }
+  }
+
+  /// Figure K.2 - Procedure to find the number of codes of each size
+  fn count_bits(&mut self) {
+    // K2
+    for i in 0..18 {
+      if self.codesize[i] > 0 {
+        self.bits[self.codesize[i] as usize] += 1;
+      }
+    } // end of K2
+
+    self.adjust_bits();
+  }
+
+  /// Section K.2 Figure K.4 Sorting of input values according to code size
+  /// The input values are sorted according to code size as shown in Figure
+  /// K.4.  HUFFVAL is the list containing the input values associated with
+  /// each code word, in order of increasing code length.
+  ///
+  /// At this point, the list of code lengths (BITS) and the list of values
+  /// (HUFFVAL) can be used to generate the code tables.  These procedures
+  /// are described in Annex C.
+  fn sort_input(&mut self) {
+    let mut k = 0;
+    for i in 1..=32 {
+      for j in 0..=16 {
+        // ssss
+        if self.codesize[j] == i {
+          self.huffval[k] = Some(j as u8);
+          k += 1;
+        }
+      }
+    }
+  }
+
+  /// Section C.2 Figure C.1 Generation of table of Huffman code sizes
+  fn gen_size_table(&mut self) -> usize {
+    let mut k = 0;
+    let mut i = 1;
+
+    while i <= 16 {
+      let mut j = 1;
+      while j <= self.bits[i] {
+        self.huffcode[k].bits = i as u16;
+        j += 1;
+        k += 1;
+      }
+      i += 1;
+    }
+    self.huffcode[k].bits = 0;
+    return k;
+  }
+
+  /// Section C.2 Figure C.2 Generation of table of Huffman codes
+  fn gen_code_table(&mut self) {
+    let mut k = 0;
+    let mut code = 0;
+    let mut si = self.huffcode[0].bits;
+    loop {
+      loop {
+        self.huffcode[k].enc = code;
+        code += 1;
+        k += 1;
+        if self.huffcode[k].bits != si {
+          break;
+        }
+      }
+      if self.huffcode[k].bits == 0 {
+        break;
+      }
+      loop {
+        code <<= 1;
+        si += 1;
+        if self.huffcode[k].bits == si {
+          break;
+        }
+      }
+    }
+  }
+
+  /// Section C.2 Figure C.3 Ordering procedure for encoding code tables
+  fn order_codes(&mut self, _lastk: usize) {
+    for (i, ssss) in self.huffval.iter().enumerate() {
+      if let Some(ssss) = ssss {
+        self.huffsym[*ssss as usize] = Some(i);
+      }
+    }
+  }
+
+  /// Section K.2 Figure K.3 Procedure for limiting code lengths to 16 bits
+  ///
+  /// Figure K.3 gives the procedure for adjusting the BITS list so that no
+  /// code is longer than 16 bits.  Since symbols are paired for the
+  /// longest Huffman code, the symbols are removed from this length
+  /// category two at a time.  The prefix for the pair (which is one bit
+  /// shorter) is allocated to one of the pair; then (skipping the BITS
+  /// entry for that prefix length) a code word from the next shortest
+  /// non-zero BITS entry is converted into a prefix for two code words one
+  /// bit longer.  After the BITS list is reduced to a maximum code length
+  /// of 16 bits, the last step removes the reserved code point from the
+  /// code length count.
+  fn adjust_bits(&mut self) {
+    let mut i = 32;
+
+    while i > 16 {
+      if self.bits[i] > 0 {
+        let mut j = i - 2;
+        while self.bits[j] == 0 {
+          j = j - 1;
+        }
+        self.bits[i] -= 2;
+        self.bits[i - 1] += 1;
+        self.bits[j + 1] += 2;
+        self.bits[j] -= 1;
+      } else {
+        i = i - 1;
+      }
+    }
+
+    while self.bits[i] == 0 {
+      i = i - 1;
+    }
+    self.bits[i] -= 1;
+  }
+
+  /// Build Huffman table
+  fn build(mut self) -> [BitArray16; HuffTableBuilder::CLASSES] {
+    self.gen_codesizes();
+    self.count_bits();
+    self.sort_input();
+    let lastk = self.gen_size_table();
+    self.gen_code_table();
+    self.order_codes(lastk);
+    let mut table = [BitArray16::default(); HuffTableBuilder::CLASSES];
+
+    for ssss in 0..=16 {
+      if let Some(code) = self.huffsym[ssss] {
+        let enc = &self.huffcode[code];
+        inspector!("ssss: {}, enc.bits: {}", ssss, enc.bits);
+        table[ssss as usize] = BitArray16::from_lsb(enc.bits as usize, enc.enc);
+      }
+    }
+
+    #[cfg(feature = "inspector")]
+    {
+      for (class, val) in self.huffcode.iter().enumerate() {
+        inspector!("huffcode: idx: {}, bitlen: {}, {:b}", class, val.bits, val.enc);
+      }
+
+      for (class, val) in self.huffval.iter().enumerate() {
+        inspector!("huffval: idx: {}, ssss: {:?}", class, val);
+      }
+
+      for (idx, bitlen) in self.bits.iter().enumerate() {
+        inspector!("bits: codelen: {}, value_count: {}", idx, bitlen);
+      }
+
+      for (class, val) in self.huffsym.iter().enumerate() {
+        inspector!("hufsym: ssss: {}, code_idx: {:?}", class, val);
+      }
+    }
+    table
+  }
+
+  /// This is a manual optimized table for most regular images
+  /// Useful for testing only.
+  fn _generic_table(histogram: [usize; Self::CLASSES], _resolution: f32) -> [BitArray16; HuffTableBuilder::CLASSES] {
+    let mut dist: Vec<(usize, usize)> = histogram.iter().enumerate().map(|(a, b)| (a, b.clone())).collect();
+    dist.sort_by(|a, b| b.1.cmp(&a.1));
+    #[cfg(feature = "inspector")]
+    for (i, f) in &dist {
+      inspector!("Freq: {}: {}, {}", i, f, *f as f32 / _resolution);
+    }
+    let mut table = [BitArray16::default(); HuffTableBuilder::CLASSES];
+    table[dist[00].0] = BitArray16::from_lsb(02, 0b00);
+    table[dist[01].0] = BitArray16::from_lsb(03, 0b010);
+    table[dist[02].0] = BitArray16::from_lsb(03, 0b011);
+    table[dist[03].0] = BitArray16::from_lsb(03, 0b100);
+    table[dist[04].0] = BitArray16::from_lsb(03, 0b101);
+    table[dist[05].0] = BitArray16::from_lsb(03, 0b110);
+    table[dist[06].0] = BitArray16::from_lsb(04, 0b1110);
+    table[dist[07].0] = BitArray16::from_lsb(05, 0b11110);
+    table[dist[08].0] = BitArray16::from_lsb(06, 0b111110);
+    table[dist[09].0] = BitArray16::from_lsb(07, 0b1111110);
+    table[dist[10].0] = BitArray16::from_lsb(08, 0b11111110);
+    table[dist[11].0] = BitArray16::from_lsb(09, 0b111111110);
+    table[dist[12].0] = BitArray16::from_lsb(10, 0b1111111110);
+    table[dist[13].0] = BitArray16::from_lsb(11, 0b11111111110);
+    table[dist[14].0] = BitArray16::from_lsb(12, 0b111111111110);
+    table[dist[15].0] = BitArray16::from_lsb(13, 0b1111111111110);
+    table[dist[16].0] = BitArray16::from_lsb(14, 0b11111111111110);
+
+    table
+  }
+}
+
+/// State for one component of the image
+#[derive(Default, Clone, Debug)]
+struct ComponentState {
+  /// Histogram of component
+  histogram: [usize; 17],
+  /// Huffman table for component
+  hufftable: [BitArray16; HuffTableBuilder::CLASSES],
+}
+
+/// Bitstream for JPEG encoded data
+pub struct BitstreamJPEG<'a> {
+  inner: &'a mut dyn Write,
+  next: u8,
+  used: usize,
+}
+
+impl<'a> BitstreamJPEG<'a> {
+  pub fn new(inner: &'a mut dyn Write) -> Self {
+    Self { inner, next: 0, used: 0 }
+  }
+
+  pub fn write_bit(&mut self, value: bool) -> std::io::Result<()> {
+    self.write(1, if value { 1 } else { 0 })
+  }
+
+  pub fn write(&mut self, mut bits: usize, value: u64) -> std::io::Result<()> {
+    while bits > 0 {
+      // flush buffer if full
+      if self.used == 8 {
+        self.internal_flush()?;
+      }
+      // how many bits are free?
+      let free = 8 - self.used;
+      // take exactly
+      let take = min(bits, free);
+      // peeked bits from value
+      let peek = ((value >> (bits - take)) & ((1 << take) - 1)) as u8;
+      // add peeked bits to buffer
+      self.next |= peek << (free - take);
+      // reduce consumed bits
+      bits -= take;
+      self.used += take;
+    }
+    Ok(())
+  }
+
+  fn internal_flush(&mut self) -> std::io::Result<()> {
+    self.inner.write_u8(self.next)?;
+    if self.next == 0xFF {
+      // Byte stuffing
+      self.inner.write_u8(0x00)?;
+    }
+    self.used = 0;
+    self.next = 0;
+    Ok(())
+  }
+
+  pub fn flush(&mut self) -> std::io::Result<()> {
+    if self.used > 0 {
+      self.internal_flush()?;
+    }
+    Ok(())
+  }
 }
 
 impl<'a> LjpegCompressor<'a> {
   /// Create a new LJPEG encoder
   ///
   /// skip_len is given as byte count after a row width.
-  pub fn new(image: &'a [u16], width: usize, height: usize, bitdepth: u8, skip_len: usize) -> Result<Self> {
-    if image.len() < height * (width + skip_len) {
+  pub fn new(image: &'a [u16], width: usize, height: usize, components: usize, bitdepth: u8, predictor: u8, skip_len: usize) -> Result<Self> {
+    if !(1..=7).contains(&predictor) {
+      return Err(CompressorError::Overflow(format!("Unsupported predictor: {}", predictor)));
+    }
+    if image.len() < height * (width * components + skip_len) {
       return Err(CompressorError::Overflow(format!(
         "Image input buffer is not large enough for given dimensions"
       )));
@@ -104,35 +495,39 @@ impl<'a> LjpegCompressor<'a> {
         width
       )));
     }
+    let point_transform = 0;
     Ok(Self {
       image,
       width,
       height,
-      components: 1, // TODO: support more components
+      components,
       bitdepth,
-      max_value: ((1u32 << bitdepth) - 1) as u16,
+      max_value: ((1u32 << (bitdepth - point_transform)) - 1) as u16,
+      point_transform,
+      predictor,
       skip_len,
-      // not sure if *3 is required, it was copied from original code
-      // but as we have only 1-component code...
-      // encoded: Cursor::new(Vec::with_capacity(width * height * 3 + 200)),
-      encoded: Cursor::new(Vec::with_capacity(width * height + 200)),
-      hist: [0; 17],
-      bits: [0; 17],
-      huffval: [0; 17],
-      huffenc: [0; 17],
-      huffbits: [0; 17],
-      huffsym: [0; 17],
+      comp_state: vec![ComponentState::default(); components],
     })
+  }
+
+  fn components(&self) -> std::ops::Range<usize> {
+    (0..self.components).into_iter()
   }
 
   /// Encode input data and consume instance
   pub fn encode(mut self) -> Result<Vec<u8>> {
+    let mut encoded = Cursor::new(Vec::with_capacity(self.resolution() * self.components));
     self.scan_frequency()?;
-    self.create_encode_table()?;
-    self.write_header()?;
-    self.write_body()?;
-    self.write_post()?;
-    Ok(self.encoded.into_inner())
+    for comp in self.components() {
+      self.build_hufftable(comp);
+      //self.create_default_table(comp)?;
+      //self.create_encode_table(comp)?;
+    }
+
+    self.write_header(&mut encoded)?;
+    self.write_body(&mut encoded)?;
+    self.write_post(&mut encoded)?;
+    Ok(encoded.into_inner())
   }
 
   /// Resolution of input image
@@ -141,25 +536,76 @@ impl<'a> LjpegCompressor<'a> {
     self.height * self.width
   }
 
-  /// Predict the Px value
-  /// Only predictor 1 is supported.
+  fn row_len(&self) -> usize {
+    self.width * self.components
+  }
+
   #[inline(always)]
-  fn predict_px(&self, prev_row: Option<&[u16]>, current_row: &[u16], row: usize, col: usize, predictor: usize) -> u16 {
-    match predictor {
-      1 => {
-        if row == 0 && col == 0 {
-          1u16 << (self.bitdepth - 1)
-        } else if col == 0 {
-          // prev_row must be Some() here
-          prev_row.unwrap()[col]
-        } else {
-          current_row[col - 1]
-        }
+  fn px_ra(current_row: &[u16], col: usize, comp: usize, cc: usize, pt: u8) -> i32 {
+    (current_row[((col - 1) * cc) + comp] >> pt) as i32
+  }
+
+  #[inline(always)]
+  fn px_rb(prev_row: &[u16], _current_row: &[u16], col: usize, comp: usize, cc: usize, pt: u8) -> i32 {
+    (prev_row[(col * cc) + comp] >> pt) as i32
+  }
+
+  #[inline(always)]
+  fn px_rc(prev_row: &[u16], _current_row: &[u16], col: usize, comp: usize, cc: usize, pt: u8) -> i32 {
+    (prev_row[((col - 1) * cc) + comp] >> pt) as i32
+  }
+
+  /// Predict the Px value
+  fn predict_px(&self, prev_row: Option<&[u16]>, current_row: &[u16], row: usize, col: usize, comp: usize) -> i32 {
+    let cc = self.components; // component count
+    let pt = self.point_transform;
+    match (row, col) {
+      // First sample
+      (0, 0) => (1u16 << (self.bitdepth - pt - 1)) as i32,
+      // First row always used Ra prediction
+      (0, col) => Self::px_ra(current_row, col, comp, cc, pt),
+      // For first column at any row
+      (_, 0) => {
+        let prev_row = prev_row.expect("Previous row expected");
+        Self::px_rb(prev_row, current_row, col, comp, cc, pt)
       }
-      _ => {
-        // We panic here because supported predictor check
-        // is done earlier.
-        panic!("unsupported predictor")
+      // Regular prediction mode
+      (row, col) => {
+        assert!(row > 0);
+        let prev_row = prev_row.expect("Previous row expected");
+        match self.predictor {
+          1 => Self::px_ra(current_row, col, comp, cc, pt),
+          2 => Self::px_rb(prev_row, current_row, col, comp, cc, pt),
+          3 => Self::px_rc(prev_row, current_row, col, comp, cc, pt),
+          4 => {
+            let ra = Self::px_ra(current_row, col, comp, cc, pt);
+            let rb = Self::px_rb(prev_row, current_row, col, comp, cc, pt);
+            let rc = Self::px_rc(prev_row, current_row, col, comp, cc, pt);
+            ra + rb - rc
+          }
+          5 => {
+            let ra = Self::px_ra(current_row, col, comp, cc, pt);
+            let rb = Self::px_rb(prev_row, current_row, col, comp, cc, pt);
+            let rc = Self::px_rc(prev_row, current_row, col, comp, cc, pt);
+            ra + ((rb - rc) >> 1)
+          }
+          6 => {
+            let ra = Self::px_ra(current_row, col, comp, cc, pt);
+            let rb = Self::px_rb(prev_row, current_row, col, comp, cc, pt);
+            let rc = Self::px_rc(prev_row, current_row, col, comp, cc, pt);
+            rb + ((ra - rc) >> 1)
+          }
+          7 => {
+            let ra = Self::px_ra(current_row, col, comp, cc, pt);
+            let rb = Self::px_rb(prev_row, current_row, col, comp, cc, pt);
+            (ra + rb) / 2
+          }
+          _ => {
+            // We panic here because supported predictor check
+            // is done earlier.
+            panic!("unsupported predictor")
+          }
+        }
       }
     }
   }
@@ -168,351 +614,290 @@ impl<'a> LjpegCompressor<'a> {
   fn scan_frequency(&mut self) -> Result<()> {
     let mut prev_row = None;
     for row in 0..self.height {
-      let curr_offset = row * (self.width + self.skip_len);
-      let current_row = &self.image[curr_offset..curr_offset + self.width];
+      let curr_offset = row * (self.row_len() + self.skip_len);
+      let current_row = &self.image[curr_offset..curr_offset + self.row_len()];
       if row > 0 {
-        let prev_offset = (row - 1) * (self.width + self.skip_len);
-        prev_row = Some(&self.image[prev_offset..prev_offset + self.width]);
+        let prev_offset = (row - 1) * (self.row_len() + self.skip_len);
+        prev_row = Some(&self.image[prev_offset..prev_offset + self.row_len()]);
       }
       for col in 0..self.width {
-        let sample = current_row[col];
-        if sample > self.max_value {
-          debug!("sample: {:#x} max: {:#x}", sample, self.max_value);
-          return Err(CompressorError::Overflow(format!(
-            "Sample overflow, sample is {:#x} but max value is {:#x}",
-            sample, self.max_value
-          )));
+        for comp in self.components() {
+          let sample = current_row[(col * self.components) + comp] >> self.point_transform;
+          if sample > self.max_value {
+            inspector!("sample: {:#x} max: {:#x}", sample, self.max_value);
+            return Err(CompressorError::Overflow(format!(
+              "Sample overflow, sample is {:#x} but max value is {:#x}",
+              sample, self.max_value
+            )));
+          }
+          let px = self.predict_px(prev_row, current_row, row, col, comp);
+          let diff: i32 = sample as i32 - px;
+          let ssss = if diff == 0 { 0 } else { 32 - diff.abs().leading_zeros() };
+          self.comp_state[comp].histogram[ssss as usize] += 1;
         }
-        let px = self.predict_px(prev_row, current_row, row, col, 1);
-        let diff: i32 = sample as i32 - px as i32;
-        let ssss = if diff == 0 { 0 } else { 32 - diff.abs().leading_zeros() };
-        //debug!("ssss: {}", ssss);
-        self.hist[ssss as usize] += 1;
       }
     }
-    #[cfg(debug_assertions)]
-    for i in 0..17 {
-      debug!("scan: {}:{}", i, self.hist[i]);
+    #[cfg(feature = "inspector")]
+    for comp in self.components() {
+      inspector!("Huffman table {}", comp);
+      for i in 0..17 {
+        inspector!("scan: self.huffman[{}].hist[{}]={}", comp, i, self.comp_state[comp].histogram[i]);
+      }
     }
     Ok(())
   }
 
-  /// Create encode table
-  fn create_encode_table(&mut self) -> Result<()> {
-    let mut freq: [f32; 18] = [0.0; 18];
-    let mut codesize: [i32; 18] = [0; 18];
-    let mut others: [i32; 18] = [0; 18];
-
-    let totalpixels: f32 = self.resolution() as f32;
-
-    // We fill the first 17 entries, the last one is filled seperately
-    for i in 0..17 {
-      freq[i] = (self.hist[i] as f32) / totalpixels;
-      codesize[i] = 0;
-      others[i] = -1;
-    }
-    freq[17] = 1.0;
-    codesize[17] = 0;
-    others[17] = -1;
-
-    loop {
-      let mut v1f: f32 = 3.0;
-      let mut v2f: f32 = 3.0;
-      let mut v1: i32 = -1;
-      let mut v2: i32 = -1;
-      for i in 0..18 {
-        if freq[i] <= v1f && freq[i] > 0.0 {
-          v1f = freq[i];
-          v1 = i as i32;
-        }
-      }
-      for i in 0..18 {
-        if i == v1 as usize {
-          continue;
-        }
-        if freq[i] < v2f && freq[i] > 0.0 {
-          v2f = freq[i];
-          v2 = i as i32;
-        }
-      }
-      if v2 == -1 {
-        break;
-      } // Done
-
-      freq[v1 as usize] += freq[v2 as usize];
-      freq[v2 as usize] = 0.0;
-
-      loop {
-        codesize[v1 as usize] += 1;
-        if others[v1 as usize] == -1 {
-          break;
-        }
-        v1 = others[v1 as usize];
-      }
-      others[v1 as usize] = v2;
-      loop {
-        codesize[v2 as usize] += 1;
-        if others[v2 as usize] == -1 {
-          break;
-        }
-        v2 = others[v2 as usize];
-      }
-    }
-    for i in 0..18 {
-      if codesize[i] != 0 {
-        self.bits[codesize[i] as usize] += 1;
+  fn build_hufftable(&mut self, comp: usize) {
+    #[cfg(feature = "inspector")]
+    {
+      let distibution: Vec<(u16, usize)> = self.comp_state[comp].histogram.iter().enumerate().map(|(a, b)| (a as u16, b.clone())).collect();
+      for (i, f) in &distibution {
+        inspector!("unsorted freq: {}: {}, {}", i, f, *f as f32 / (self.resolution() as f32));
       }
     }
 
-    #[cfg(debug_assertions)]
-    for i in 0..17 {
-      debug!("bits:{},{},{}", i, self.bits[i], codesize[i]);
+    let huffgen = HuffTableBuilder::new(self.comp_state[comp].histogram.clone(), self.resolution() as f32);
+    let table = huffgen.build();
+    //let table = HuffTableBuilder::_generic_table(self.huffman[comp].hist.clone());
+    #[cfg(feature = "inspector")]
+    for (i, code) in table.iter().enumerate() {
+      inspector!("table[{}]={}", i, code);
     }
-
-    let mut k = 0;
-    for i in 1..=32 {
-      for j in 0..17 {
-        if codesize[j] == i {
-          self.huffval[k] = j as u8;
-          k += 1;
-        }
-      }
-    }
-
-    #[cfg(debug_assertions)]
-    for i in 0..17 {
-      debug!("i={},huffval[i]={:#x}", i, self.huffval[i]);
-    }
-
-    let mut maxbits = 16;
-    while maxbits > 0 {
-      if self.bits[maxbits] != 0 {
-        break;
-      }
-      maxbits -= 1;
-    }
-
-    let mut bitsused = 1;
-    let mut _hv = 0;
-    let mut rv = 0;
-    let mut vl = 0;
-    let mut sym = 0;
-    let mut i: u32 = 0;
-    while i < (1 << maxbits) {
-      if bitsused > maxbits {
-        panic!("This should never happen");
-      }
-      if vl >= self.bits[bitsused] {
-        bitsused += 1;
-        vl = 0;
-        continue;
-      }
-      if rv == (1 << (maxbits - bitsused)) {
-        rv = 0;
-        vl += 1;
-        _hv += 1;
-        continue;
-      }
-      self.huffbits[sym] = bitsused as u16;
-      self.huffenc[sym] = (i >> (maxbits - bitsused)) as u16;
-      sym += 1;
-      i += 1 << (maxbits - bitsused);
-      rv = 1 << (maxbits - bitsused);
-    }
-    for i in 0..17 {
-      if self.huffbits[i] > 0 {
-        self.huffsym[self.huffval[i] as usize] = i;
-      }
-      #[cfg(debug_assertions)]
-      debug!(
-        "huffval[{}]={},huffenc[{}]={:#x},bits={}",
-        i, self.huffval[i], i, self.huffenc[i], self.huffbits[i]
-      );
-    }
-
-    #[cfg(debug_assertions)]
-    for i in 0..17 {
-      debug!("huffsym[{}]={}", i, self.huffsym[i]);
-    }
-
-    Ok(())
+    self.comp_state[comp].hufftable = table;
   }
 
   /// Write JPEG header
-  fn write_header(&mut self) -> Result<()> {
-    self.encoded.write_u16::<BigEndian>(0xffd8)?; // SOI
-    self.encoded.write_u16::<BigEndian>(0xffc3)?; // SOF_3 Lossless (sequential), Huffman coding
+  fn write_header(&mut self, encoded: &mut dyn Write) -> Result<()> {
+    encoded.write_u16::<BigEndian>(0xffd8)?; // SOI
+    encoded.write_u16::<BigEndian>(0xffc3)?; // SOF_3 Lossless (sequential), Huffman coding
 
     // Write SOF
-    self
-      .encoded
-      .write_u16::<BigEndian>(2 + 6 + self.components as u16 * 3)?; // Lf, frame header length
-    self.encoded.write_u8(self.bitdepth)?; // Sample precision P
-    self.encoded.write_u16::<BigEndian>(self.height as u16)?;
-    self.encoded.write_u16::<BigEndian>(self.width as u16)?;
+    encoded.write_u16::<BigEndian>(2 + 6 + self.components as u16 * 3)?; // Lf, frame header length
+    encoded.write_u8(self.bitdepth)?; // Sample precision P
+    encoded.write_u16::<BigEndian>(self.height as u16)?;
+    encoded.write_u16::<BigEndian>(self.width as u16)?;
 
-    self.encoded.write_u8(self.components)?; // Components Nf
-    for c in 0..self.components {
-      self.encoded.write_u8(c)?; // Component ID
-      self.encoded.write_u8(0x11)?; // H_i / V_i, Sampling factor 0001 0001
-      self.encoded.write_u8(0)?; // Quantisation table Tq (not used for lossless)
+    encoded.write_u8(self.components as u8)?; // Components Nf
+    for c in self.components() {
+      encoded.write_u8(c as u8)?; // Component ID
+      encoded.write_u8(0x11)?; // H_i / V_i, Sampling factor 0001 0001
+      encoded.write_u8(0)?; // Quantisation table Tq (not used for lossless)
     }
 
-    // Write HUFF
-    self.encoded.write_u16::<BigEndian>(0xffc4)?;
-    let bit_sum: u16 = self.bits.iter().cloned().map(u16::from).sum();
+    for comp in self.components() {
+      // Write HUFF
+      encoded.write_u16::<BigEndian>(0xffc4)?;
 
-    debug!("Bitsum: {}", bit_sum);
-    self.encoded.write_u16::<BigEndian>(17 + 2 + bit_sum)?; // Lf, frame header length
-    self.encoded.write_u8(0)?; // Table ID
-    for i in 1..17 {
-      self.encoded.write_u8(self.bits[i])?;
+      let bit_sum: u16 = self.comp_state[comp].hufftable.iter().filter(|e| e.len() > 0).count() as u16;
+      inspector!("Bitsum: {}", bit_sum);
+
+      encoded.write_u16::<BigEndian>(2 + (1 + 16) + bit_sum)?; // Lf, frame header length
+      encoded.write_u8(comp as u8)?; // Table ID
+
+      // Write for each of the 16 possible code lengths how many codes
+      // exists with the correspoding length.
+      for bit_len in 1..=16 {
+        let count = self.comp_state[comp].hufftable.iter().filter(|entry| entry.len() == bit_len).count();
+        inspector!("COUNT: {}={}", bit_len, count);
+        encoded.write_u8(count as u8)?;
+      }
+
+      for bit_len in 1..=16 {
+        let mut codes: Vec<(u16, BitArray16)> = self.comp_state[comp]
+          .hufftable
+          .iter()
+          .enumerate()
+          .filter(|(_, code)| code.len() == bit_len)
+          .map(|(ssss, code)| (ssss as u16, code.clone()))
+          .collect();
+        codes.sort_by(|a, b| a.1.cmp(&b.1));
+        for (ssss, _) in codes.iter() {
+          encoded.write_u8(*ssss as u8)?;
+          inspector!("VAL: {}", ssss);
+        }
+      }
     }
-    for i in 0..bit_sum as usize {
-      self.encoded.write_u8(self.huffval[i])?;
-    }
+
     // Write SCAN
-    self.encoded.write_u16::<BigEndian>(0xffda)?; // SCAN
-    self
-      .encoded
-      .write_u16::<BigEndian>(0x0006 + (self.components as u16 * 2))?; // Ls, scan header length
-    self.encoded.write_u8(self.components)?; // Ns, Component count
-
-    for c in 0..self.components {
-      self.encoded.write_u8(c)?; // Cs_i, Component selector
-      self.encoded.write_u8(0)?; // Td, Ta, DC/AC entropy table selector
+    encoded.write_u16::<BigEndian>(0xffda)?; // SCAN
+    encoded.write_u16::<BigEndian>(0x0006 + (self.components as u16 * 2))?; // Ls, scan header length
+    encoded.write_u8(self.components as u8)?; // Ns, Component count
+    for c in self.components() {
+      encoded.write_u8(c as u8)?; // Cs_i, Component selector
+      encoded.write_u8((c as u8) << 4)?; // Td, Ta, DC/AC entropy table selector
     }
-    self.encoded.write_u8(1)?; // Ss, Predictor for lossless
-    self.encoded.write_u8(0)?; // Se, ignored for lossless
-    self.encoded.write_u8(0)?; // Ah, ignored for lossless
-
+    encoded.write_u8(self.predictor)?; // Ss, Predictor for lossless
+    encoded.write_u8(0)?; // Se, ignored for lossless
+    assert!(self.point_transform <= 15);
+    encoded.write_u8(0x00 | (self.point_transform & 0xF))?; // Ah=0, Al=Point transform
     Ok(())
   }
 
   /// Write JPEG post
-  fn write_post(&mut self) -> Result<()> {
-    self.encoded.write_u16::<BigEndian>(0xffd9)?; // EOI
+  fn write_post(&mut self, encoded: &mut dyn Write) -> Result<()> {
+    encoded.write_u16::<BigEndian>(0xffd9)?; // EOI
     Ok(())
   }
 
   /// Write JPEG body
-  fn write_body(&mut self) -> Result<()> {
-    let mut bitcount = 0;
-    let mut next: u8 = 0;
-    let mut nextbits: u16 = 8;
+  fn write_body(&mut self, encoded: &mut dyn Write) -> Result<()> {
+    let mut bitstream = BitstreamJPEG::new(encoded);
+
     let mut prev_row = None;
     for row in 0..self.height {
-      let curr_offset = row * (self.width + self.skip_len);
-      let current_row = &self.image[curr_offset..curr_offset + self.width];
+      let curr_offset = row * (self.row_len() + self.skip_len);
+      let current_row = &self.image[curr_offset..curr_offset + self.row_len()];
       if row > 0 {
-        let prev_offset = (row - 1) * (self.width + self.skip_len);
-        prev_row = Some(&self.image[prev_offset..prev_offset + self.width]);
+        let prev_offset = (row - 1) * (self.row_len() + self.skip_len);
+        prev_row = Some(&self.image[prev_offset..prev_offset + self.row_len()]);
       }
+
       for col in 0..self.width {
-        let sample = current_row[col];
-        if sample > self.max_value {
-          return Err(CompressorError::Overflow(format!(
-            "Sample overflow, sample is {:#x} but max value is {:#x}",
-            sample, self.max_value
-          )));
-        }
-        let px = self.predict_px(prev_row, current_row, row, col, 1);
-        let mut diff: i32 = sample as i32 - px as i32;
-        let mut ssss = if diff == 0 { 0 } else { 32 - diff.abs().leading_zeros() };
-
-        // Write the huffman code for ssss value
-        let huffcode = self.huffsym[ssss as usize];
-        let mut huffenc = self.huffenc[huffcode ];
-        let mut huffbits = self.huffbits[huffcode as usize];
-        bitcount = bitcount + huffbits as u32 + ssss as u32;
-
-        let vt = if ssss > 0 { 1 << (ssss - 1) } else { 0 };
-
-        if diff < vt {
-          diff += (1 << ssss) - 1;
-        }
-
-        // Write the ssss
-        while huffbits > 0 {
-          let usebits: u16 = if huffbits > nextbits { nextbits } else { huffbits };
-          // Add top usebits from huffval to next usebits of nextbits
-          let tophuff: i32 = (huffenc >> (huffbits - usebits)) as i32;
-          next |= (tophuff << (nextbits - usebits)) as u8; // accept bit loss
-          nextbits -= usebits;
-          huffbits -= usebits;
-          huffenc &= (1 << huffbits) - 1;
-          if nextbits == 0 {
-            self.encoded.write_u8(next)?;
-            if next == 0xff {
-              self.encoded.write_u8(0x00)?;
-            }
-            next = 0;
-            nextbits = 8;
+        for comp in self.components() {
+          let sample = current_row[(col * self.components) + comp] >> self.point_transform;
+          if sample > self.max_value {
+            return Err(CompressorError::Overflow(format!(
+              "Sample overflow, sample is {:#x} but max value is {:#x}",
+              sample, self.max_value
+            )));
           }
-        }
+          let px = self.predict_px(prev_row, current_row, row, col, comp);
+          let mut diff: i32 = sample as i32 - px;
+          //inspector!("Sample: {}, px: {}, diff: {}", sample, px, diff);
+          let ssss = if diff == 0 { 0 } else { 32 - diff.abs().leading_zeros() };
 
-        // Write the rest of the bits for the value
-        while ssss > 0 {
-          assert!(ssss <= u16::MAX as u32);
-          let usebits: u16 = if ssss > nextbits as u32 { nextbits } else { ssss as u16 };
-          // Add top usebits from huffval to next usebits of nextbits
-          let tophuff: i32 = diff >> (ssss - usebits as u32);
-          next |= (tophuff << (nextbits - usebits)) as u8; // accept bit loss
-          nextbits -= usebits;
-          ssss -= usebits as u32;
-          diff &= (1 << ssss) - 1;
-          if nextbits == 0 {
-            self.encoded.write_u8(next)?;
-            if next == 0xff {
-              self.encoded.write_u8(0x00)?;
-            }
-            next = 0;
-            nextbits = 8;
+          let enc = self.comp_state[comp].hufftable[ssss as usize];
+
+          let (bits, value) = (enc.len(), enc.get_lsb() as u64);
+          assert!(bits > 0);
+          //inspector!("bits: {}, value: {:b}", bits, value);
+          bitstream.write(bits, value)?;
+
+          // Sign encoding
+          let vt = if ssss > 0 { 1 << (ssss - 1) } else { 0 };
+          if diff < vt {
+            diff += (1 << ssss) - 1;
+          }
+
+          assert!(diff <= (diff & (1 << ssss) - 1));
+          //inspector!("diff: {}, ssss: {}", diff, ssss);
+
+          // Write the rest of the bits for the value
+          // For ssss == 16 no additional bits are written
+          if ssss == 16 {
+            // ignore
+          } else {
+            bitstream.write(ssss as usize, diff as u64)?;
           }
         }
       }
     } // pixel loop
 
     // Flush the final bits
-    if nextbits < 8 {
-      self.encoded.write_u8(next)?;
-      if next == 0xff {
-        self.encoded.write_u8(0x00)?;
-      }
-    }
-
-    #[cfg(debug_assertions)]
-    {
-      for i in 0..17 {
-        debug!("{}:{}", i, self.hist[i]);
-      }
-      debug!("Total bytes: {}", bitcount >> 3);
-    }
-
+    bitstream.flush()?;
     Ok(())
   }
 }
 
 #[cfg(test)]
 mod tests {
+  use simple_logger::SimpleLogger;
+
   use super::*;
   /// We reuse the decompressor to check both...
   use crate::decompressors::ljpeg::LjpegDecompressor;
 
   #[test]
-  fn encode_16x16_16bit_black_decode() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  fn bitstream_test1() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    let mut buf = Vec::new();
+    let mut bs = BitstreamJPEG::new(&mut buf);
+    bs.write(1, 0b1)?;
+    bs.flush()?;
+    bs.write(1, 0b0)?;
+    bs.write(3, 0b101)?;
+    bs.write(4, 0b11111101)?;
+    bs.write(2, 0b101)?;
+    bs.flush()?;
+    bs.write(16, 0b1111111111111111)?;
+    bs.flush()?;
+    bs.write(16, 0b0)?;
+    bs.flush()?;
+    drop(bs);
+    assert_eq!(buf[0], 0b10000000);
+    assert_eq!(buf[1], 0b01011101);
+    assert_eq!(buf[2], 0b01000000);
+    assert_eq!(buf[3], 0xFF);
+    assert_eq!(buf[4], 0x00); // stuffing
+    assert_eq!(buf[5], 0xFF);
+    assert_eq!(buf[6], 0x00); // stuffing
+    assert_eq!(buf[7], 0x00);
+    Ok(())
+  }
+
+  #[test]
+  fn encode_16x16_16bit_black_decode_single() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(h * w);
-    input_image.resize(h * w, 0x0000_u16);
-    let enc = LjpegCompressor::new(&input_image, w, h, 16, 0)?;
+    let c = 1;
+    let input_image = vec![0x0000; w * h * c];
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
     let result = enc.encode();
     assert!(result.is_ok());
     let jpeg = result?;
     let dec = LjpegDecompressor::new(&jpeg)?;
     let mut outbuf = Vec::with_capacity(h * w);
     outbuf.resize(h * w, 0);
-    dec.decode(&mut outbuf, 0, w, w, h, false)?;
+    dec.decode(&mut outbuf, 0, w * c, w * c, h, false)?;
+    assert_eq!(outbuf[0], input_image[0]);
+    assert_eq!(outbuf[1], input_image[1]);
+    for i in 0..outbuf.len() {
+      assert_eq!(outbuf[i], input_image[i]);
+    }
+    Ok(())
+  }
+
+  // #[test]
+  // fn encode_4x4() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  //   let _ = SimpleLogger::new().init().unwrap_or(());
+  //   let h = 4;
+  //   let w = 4;
+  //   let c = 1;
+  //   let input_image = [
+  //     0x4321, 0xde54, 0x8432, 0xed94, 0xb465, 0x2342, 0xaa02, 0x0054, 0x5487, 0xbb09, 0xe323, 0x9954, 0x8adc, 0x8000, 0x8001, 0xbd09,
+  //   ];
+  //   let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
+  //   let result = enc.encode();
+  //   assert!(result.is_ok());
+  //   let jpeg = result?;
+  //   let dec = LjpegDecompressor::new_full(&jpeg, false, false)?;
+  //   let mut outbuf = vec![0; w * h * c];
+  //   dec.decode(&mut outbuf, 0, w * c, w * c, h, false)?;
+  //   assert_eq!(outbuf[0], input_image[0]);
+  //   assert_eq!(outbuf[1], input_image[1]);
+  //   for i in 0..outbuf.len() {
+  //     assert_eq!(outbuf[i], input_image[i]);
+  //   }
+  //   Ok(())
+  // }
+
+  #[test]
+  fn encode_16x16_16bit_black_decode_2component() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
+    let h = 2;
+    let w = 2;
+    let c = 2;
+    let input_image = vec![0x0000; w * h * c];
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
+    let result = enc.encode();
+    assert!(result.is_ok());
+    let jpeg = result?;
+    let dec = LjpegDecompressor::new_full(&jpeg, false, false)?;
+    let mut outbuf = vec![0; w * h * c];
+    dec.decode(&mut outbuf, 0, w * c, w * c, h, false)?;
+    assert_eq!(outbuf[0], input_image[0]);
+    assert_eq!(outbuf[1], input_image[1]);
     for i in 0..outbuf.len() {
       assert_eq!(outbuf[i], input_image[i]);
     }
@@ -521,11 +906,12 @@ mod tests {
 
   #[test]
   fn encode_16x16_16bit_black() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(h * w);
-    input_image.resize(h * w, 0x0000_u16);
-    let enc = LjpegCompressor::new(&input_image, w, h, 16, 0)?;
+    let c = 1;
+    let input_image = vec![0x0000; w * h * c];
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
     let result = enc.encode();
     assert!(result.is_ok());
     Ok(())
@@ -533,11 +919,12 @@ mod tests {
 
   #[test]
   fn encode_16x16_16bit_white() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(h * w);
-    input_image.resize(h * w, 0xffff_u16);
-    let enc = LjpegCompressor::new(&input_image, w, h, 16, 0)?;
+    let c = 1;
+    let input_image = vec![0xffff; w * h * c];
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
     let result = enc.encode();
     assert!(result.is_ok());
     Ok(())
@@ -545,11 +932,12 @@ mod tests {
 
   #[test]
   fn encode_16x16_bitdepth_error() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(h * w);
-    input_image.resize(h * w, 0xffff_u16);
-    let enc = LjpegCompressor::new(&input_image, w, h, 14, 0)?;
+    let c = 1;
+    let input_image = vec![0xfffe; w * h * c];
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 14, 1, 0)?;
     let result = enc.encode();
     assert!(result.is_err());
     Ok(())
@@ -557,32 +945,33 @@ mod tests {
 
   #[test]
   fn encode_16x16_short_buffer_error() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(55); // Wrong size
-    input_image.resize(55, 0x9999_u16);
-    let result = LjpegCompressor::new(&input_image, w, h, 16, 0);
+    let c = 1;
+    let input_image = vec![0x9999_u16; (w * h * c) - 1];
+    let result = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0);
     assert!(result.is_err());
     Ok(())
   }
 
   #[test]
   fn encode_16x16_16bit_incr() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let _ = SimpleLogger::new().init().unwrap_or(());
     let h = 16;
     let w = 16;
-    let mut input_image = Vec::with_capacity(h * w);
-    input_image.resize(h * w, 0x0000_u16);
+    let c = 2;
+    let mut input_image = vec![0; h * w * c];
     for i in 0..input_image.len() {
       input_image[i] = i as u16;
     }
-    let enc = LjpegCompressor::new(&input_image, w, h, 16, 0)?;
+    let enc = LjpegCompressor::new(&input_image, w, h, c, 16, 1, 0)?;
     let result = enc.encode();
     assert!(result.is_ok());
     let jpeg = result?;
-    let dec = LjpegDecompressor::new(&jpeg)?;
-    let mut outbuf = Vec::with_capacity(h * w);
-    outbuf.resize(h * w, 0);
-    dec.decode(&mut outbuf, 0, w, w, h, false)?;
+    let dec = LjpegDecompressor::new_full(&jpeg, false, false)?;
+    let mut outbuf = vec![0; h * w * c];
+    dec.decode(&mut outbuf, 0, w * c, w * c, h, false)?;
     for i in 0..outbuf.len() {
       assert!((outbuf[i] as i32 - input_image[i] as i32).abs() < 2);
     }

--- a/rawler/src/pumps.rs
+++ b/rawler/src/pumps.rs
@@ -226,6 +226,7 @@ impl<'a> BitPump for BitPumpJPEG<'a> {
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
+    assert!(num <= self.nbits);
     self.nbits -= num;
     self.bits &= (1 << self.nbits) - 1;
   }

--- a/rawler/src/tiles.rs
+++ b/rawler/src/tiles.rs
@@ -51,7 +51,9 @@ where
     // TODO: write tests
     let start = len / 8;
     for i in (1..start).rev() {
-      if len % i == 0 {
+      // We need mod_2 because tiles are compressed
+      // with 2-component LJPEG
+      if (len % i == 0) && (i % 2 == 0) {
         return i;
       }
     }


### PR DESCRIPTION
Add LJPEG92 improved implementation

 * Add support for predictor modes 1-7
 * Add support for point transformation
 * Add support for 1-4 component encoding

Default is 2-component encoding for Bayer images