### PR TITLE
Add support for CR3 roll files

### DIFF
--- a/CR3_STATE.md
+++ b/CR3_STATE.md
@@ -1,5 +1,8 @@
 # State of CR3 support
 
+CR3 is fully supported.
+
+
 | Make                 | State                                    | Remarks                                                                     |
 |----------------------|------------------------------------------|-----------------------------------------------------------------------------|
 | BMFF                 | ✅ Yes                                   |                                                                             |
@@ -10,5 +13,19 @@
 | CRAW decoding        | ✅ Yes                                   | Unknown compression method                                                  |
 | Dual Pixel           | ✅ Yes <sup> with restrictions </sup>    | Dual Pixel files can be decoded, but no Dual Pixel corrections are possible |
 | Thumb/Preview extraction   | ✅ Yes       | Thumbnail is generated from preview                                                               |
-| HDR PQ / HEIF        | ✅ Yes                                    | For HDR-PQ, DNG thumbnail and preview image is generated from RAW  |
-| CR3 Filmroll | ❌ No            | Filmrolls using encoding type 3                                                                            |
+| HDR PQ / HEIF        | ✅ Yes                                   | For HDR-PQ, DNG thumbnail and preview image is generated from RAW           |
+| CR3 Filmroll         | ✅ Yes                                   | Filmrolls using encoding type 3                                             |
+
+
+# Roll files
+Some models can write roll files, including up to 70 images in a single CR3 file. dnglab is able to extract all images from a roll.
+A single specific image can be extracted with:
+
+    dnglab convert --image-index <id> CSI_2839.CR3 /tmp/img1.dng
+
+All images can be extracted by:
+
+    dnglab convert --image-index all CSI_2839.CR3 /tmp/roll.dng
+
+This created roll_0000.dng, roll_0001.dng and so on. If a CR3 file contains only a single image, no number suffix is applied so
+you can always use **--image-index all**.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ For a list of supported cameras please see [SUPPORTED_CAMERAS.md](SUPPORTED_CAME
 
 | Format | Supported                         | Remarks                                |
 |--------|-----------------------------------|----------------------------------------|
-| CR3    | ✅ Yes<sup>with restrictions</sup> | [CR3_STATE.md](CR3_STATE.md)           |
-| CR2    | ❌ No<sup> planned</sup>           |                                        |
-| CRW    | ❌ No                              |                                        |
+| CR3    | ✅ Yes                            | [CR3_STATE.md](CR3_STATE.md)           |
+| CR2    | ❌ No<sup> planned</sup>          |                                        |
+| CRW    | ❌ No                             |                                        |
 
 
 ### Supported DNG features
@@ -61,6 +61,7 @@ OPTIONS:
     -c, --compression <compression>        'lossless' or 'none' [default: lossless]
         --crop <crop>                      Apply crop to ActiveArea [default: yes]
         --dng-embedded <embedded>          Embed the raw file into DNG [default: yes]
+        --image-index <index>              Select a specific image index (or 'all') if file is a image container
         --ljpeg92-predictor <predictor>    LJPEG-92 predictor (1-7)
         --dng-preview <preview>            Include a DNG preview image [default: yes]
         --dng-thumbnail <thumbnail>        Include a DNG thumbnail image [default: yes]

--- a/SUPPORTED_CAMERAS.md
+++ b/SUPPORTED_CAMERAS.md
@@ -2,16 +2,16 @@
 
 | Make  | Model                         | State                             | Remarks                                           |
 |-------|-------------------------------|-----------------------------------|---------------------------------------------------|
-| Canon | EOS R                         | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS RP                        | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS R5                        | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS R6                        | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS-1Dx Mark III              | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS 250D                      | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS 850D                      | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS 90D                       | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS M50                       | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS M50 Mark II               | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | EOS M6 Mark II                | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | Canon PowerShot G7 X Mark III | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
-| Canon | Canon PowerShot G5 X Mark II  | ✅ Yes<sup>with restrictions</sup> | CRAW (compressed RAW) and HDR PQ is not supported |
+| Canon | EOS R                         | ✅ Yes |  |
+| Canon | EOS RP                        | ✅ Yes |  |
+| Canon | EOS R5                        | ✅ Yes |  |
+| Canon | EOS R6                        | ✅ Yes |  |
+| Canon | EOS-1Dx Mark III              | ✅ Yes |  |
+| Canon | EOS 250D                      | ✅ Yes |  |
+| Canon | EOS 850D                      | ✅ Yes |  |
+| Canon | EOS 90D                       | ✅ Yes |  |
+| Canon | EOS M50                       | ✅ Yes |  |
+| Canon | EOS M50 Mark II               | ✅ Yes |  |
+| Canon | EOS M6 Mark II                | ✅ Yes |  |
+| Canon | Canon PowerShot G7 X Mark III | ✅ Yes |  |
+| Canon | Canon PowerShot G5 X Mark II  | ✅ Yes |  |

--- a/bin/dnglab/src/analyze.rs
+++ b/bin/dnglab/src/analyze.rs
@@ -5,6 +5,7 @@ use clap::ArgMatches;
 use log::debug;
 use rawler::analyze::{analyze_file, extract_raw_pixels, raw_as_pgm};
 use rawler::analyze::{raw_as_ppm16, raw_to_srgb};
+use rawler::decoders::RawDecodeParams;
 use std::{
   io::{BufWriter, Write},
   path::PathBuf,
@@ -27,10 +28,10 @@ pub fn analyze(options: &ArgMatches<'_>) -> anyhow::Result<()> {
       println!("{}", json);
     }
   } else if options.is_present("pixel") {
-    let (width, height, buf) = extract_raw_pixels(&PathBuf::from(in_file)).unwrap();
+    let (width, height, buf) = extract_raw_pixels(&PathBuf::from(in_file), RawDecodeParams::default()).unwrap();
     dump_pgm(width, height, &buf)?;
   } else if options.is_present("srgb") {
-    let (buf, dim) = raw_to_srgb(&PathBuf::from(in_file)).unwrap();
+    let (buf, dim) = raw_to_srgb(&PathBuf::from(in_file), RawDecodeParams::default()).unwrap();
     dump_ppm16(dim.w, dim.h, &buf)?;
   }
   Ok(())

--- a/bin/dnglab/src/app.rs
+++ b/bin/dnglab/src/app.rs
@@ -32,6 +32,7 @@ pub fn create_app() -> App<'static, 'static> {
           (@arg thumbnail: --("dng-thumbnail") default_value[yes] {validate_bool} "Include a DNG thumbnail image")
           (@arg embedded: --("dng-embedded") default_value[yes] {validate_bool} "Embed the raw file into DNG")
           (@arg artist: --("artist") +takes_value "Set the artist tag")
+          (@arg index: --("image-index") +takes_value "Select a specific image index (or 'all') if file is a image container")
           (@arg crop: --("crop") default_value[yes] {validate_bool} "Apply crop to ActiveArea")
           (@arg recursive: -r --recursive "Process input directory recursive")
           (@arg override: -f --override "Override existing files")

--- a/bin/dnglab/src/main.rs
+++ b/bin/dnglab/src/main.rs
@@ -39,8 +39,9 @@ fn main() -> anyhow::Result<()> {
     })
     .format(move |out, message, record| {
       out.finish(format_args!(
-        "{}[{:6}][{}] {} ({}:{})",
-        chrono::Utc::now().format("[%Y-%m-%d %H:%M:%S%z]"),
+        //"{}[{:6}][{}] {} ({}:{})",
+        //chrono::Utc::now().format("[%Y-%m-%d %H:%M:%S%z]"),
+        "[{:6}][{}] {} ({}:{})",
         colors.color(record.level()),
         record.target(),
         message,

--- a/rawler/src/bin/benchmark.rs
+++ b/rawler/src/bin/benchmark.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::fs::File;
 use std::time::Instant;
 
+use rawler::decoders::RawDecodeParams;
+
 fn usage() {
   println!("benchmark <file>");
   std::process::exit(1);
@@ -38,7 +40,7 @@ fn main() {
         Ok(val) => val,
         Err(e) => {error(&e); return},
       };
-      match decoder.raw_image(false) {
+      match decoder.raw_image(RawDecodeParams::default(), false) {
         Ok(_) => {},
         Err(e) => error(&e),
       }

--- a/rawler/src/decoders/ari.rs
+++ b/rawler/src/decoders/ari.rs
@@ -6,6 +6,7 @@ use crate::bits::*;
 use crate::packed::*;
 
 use super::Decoder;
+use super::RawDecodeParams;
 use super::ok_image;
 
 
@@ -29,7 +30,7 @@ impl<'a> AriDecoder<'a> {
 }
 
 impl<'a> Decoder for AriDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let offset = LEu32(self.buffer, 8) as usize;
     let width = LEu32(self.buffer, 20) as usize;
     let height = LEu32(self.buffer, 24) as usize;

--- a/rawler/src/decoders/arw.rs
+++ b/rawler/src/decoders/arw.rs
@@ -32,7 +32,7 @@ impl<'a> ArwDecoder<'a> {
 }
 
 impl<'a> Decoder for ArwDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let data = self.tiff.find_ifds_with_tag(TiffRootTag::StripOffsets);
     if data.len() == 0 {

--- a/rawler/src/decoders/cr2.rs
+++ b/rawler/src/decoders/cr2.rs
@@ -63,7 +63,7 @@ impl<'a> Decoder for Cr2Decoder<'a> {
     Ok(())
   }
 
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let (raw, offset) = {
       if let Some(raw) = self.tiff.find_first_ifd(TiffRootTag::Cr2Id) {

--- a/rawler/src/decoders/crw.rs
+++ b/rawler/src/decoders/crw.rs
@@ -84,7 +84,7 @@ impl<'a> CrwDecoder<'a> {
 }
 
 impl<'a> Decoder for CrwDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let makemodel = fetch_tag!(self.ciff, CiffTag::MakeModel).get_strings();
     if makemodel.len() < 2 {
       return Err("CRW: MakeModel tag needs to have 2 strings".to_string())

--- a/rawler/src/decoders/dcr.rs
+++ b/rawler/src/decoders/dcr.rs
@@ -28,7 +28,7 @@ impl<'a> DcrDecoder<'a> {
 }
 
 impl<'a> Decoder for DcrDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::CFAPattern);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/dcs.rs
+++ b/rawler/src/decoders/dcs.rs
@@ -25,7 +25,7 @@ impl<'a> DcsDecoder<'a> {
 }
 
 impl<'a> Decoder for DcsDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let data = self.tiff.find_ifds_with_tag(TiffRootTag::StripOffsets);
     let raw = data.iter().find(|&&ifd| {

--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -30,7 +30,7 @@ impl<'a> DngDecoder<'a> {
 }
 
 impl<'a> Decoder for DngDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let ifds = self.tiff.find_ifds_with_tag(TiffRootTag::Compression).into_iter().filter(|ifd| {
       let compression = (**ifd).find_entry(TiffRootTag::Compression).unwrap().get_u32(0);
       let subsampled = match (**ifd).find_entry(TiffRootTag::NewSubFileType) {

--- a/rawler/src/decoders/erf.rs
+++ b/rawler/src/decoders/erf.rs
@@ -25,7 +25,7 @@ impl<'a> ErfDecoder<'a> {
 }
 
 impl<'a> Decoder for ErfDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::CFAPattern);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/iiq.rs
+++ b/rawler/src/decoders/iiq.rs
@@ -25,7 +25,7 @@ impl<'a> IiqDecoder<'a> {
 }
 
 impl<'a> Decoder for IiqDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
 
     let off = LEu32(self.buffer, 16) as usize + 8;

--- a/rawler/src/decoders/kdc.rs
+++ b/rawler/src/decoders/kdc.rs
@@ -26,7 +26,7 @@ impl<'a> KdcDecoder<'a> {
 }
 
 impl<'a> Decoder for KdcDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
 
     if camera.model == "Kodak DC120 ZOOM Digital Camera" {

--- a/rawler/src/decoders/mef.rs
+++ b/rawler/src/decoders/mef.rs
@@ -23,7 +23,7 @@ impl<'a> MefDecoder<'a> {
 }
 
 impl<'a> Decoder for MefDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::CFAPattern);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/mos.rs
+++ b/rawler/src/decoders/mos.rs
@@ -24,7 +24,7 @@ impl<'a> MosDecoder<'a> {
 }
 
 impl<'a> Decoder for MosDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let make = self.xmp_tag("Make")?;
     let model_full = self.xmp_tag("Model")?.to_string();
     let model = model_full.split_terminator("(").next().unwrap();

--- a/rawler/src/decoders/mrw.rs
+++ b/rawler/src/decoders/mrw.rs
@@ -72,7 +72,7 @@ impl<'a> MrwDecoder<'a> {
 }
 
 impl<'a> Decoder for MrwDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let src = &self.buffer[self.data_offset..];
 

--- a/rawler/src/decoders/nef.rs
+++ b/rawler/src/decoders/nef.rs
@@ -105,7 +105,7 @@ impl<'a> NefDecoder<'a> {
 }
 
 impl<'a> Decoder for NefDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::CFAPattern);
     let mut width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);
     let height = fetch_tag!(raw, TiffRootTag::ImageLength).get_usize(0);

--- a/rawler/src/decoders/nkd.rs
+++ b/rawler/src/decoders/nkd.rs
@@ -19,7 +19,7 @@ impl<'a> NakedDecoder<'a> {
 }
 
 impl<'a> Decoder for NakedDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let width = self.camera.raw_width;
     let height = self.camera.raw_height;
     let size = self.camera.filesize;

--- a/rawler/src/decoders/nrw.rs
+++ b/rawler/src/decoders/nrw.rs
@@ -23,7 +23,7 @@ impl<'a> NrwDecoder<'a> {
 }
 
 impl<'a> Decoder for NrwDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let data = self.tiff.find_ifds_with_tag(TiffRootTag::CFAPattern);
     let raw = data.iter().find(|&&ifd| {

--- a/rawler/src/decoders/orf.rs
+++ b/rawler/src/decoders/orf.rs
@@ -25,7 +25,7 @@ impl<'a> OrfDecoder<'a> {
 }
 
 impl<'a> Decoder for OrfDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::StripOffsets);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/pef.rs
+++ b/rawler/src/decoders/pef.rs
@@ -27,7 +27,7 @@ impl<'a> PefDecoder<'a> {
 }
 
 impl<'a> Decoder for PefDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::StripOffsets);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/raf.rs
+++ b/rawler/src/decoders/raf.rs
@@ -23,7 +23,7 @@ impl<'a> RafDecoder<'a> {
 }
 
 impl<'a> Decoder for RafDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::RafOffsets);
     let (width,height) = if raw.has_entry(TiffRootTag::RafImageWidth) {

--- a/rawler/src/decoders/rw2.rs
+++ b/rawler/src/decoders/rw2.rs
@@ -24,7 +24,7 @@ impl<'a> Rw2Decoder<'a> {
 }
 
 impl<'a> Decoder for Rw2Decoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let width: usize;
     let height: usize;
     let image = {

--- a/rawler/src/decoders/srw.rs
+++ b/rawler/src/decoders/srw.rs
@@ -28,7 +28,7 @@ impl<'a> SrwDecoder<'a> {
 }
 
 impl<'a> Decoder for SrwDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::StripOffsets);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/tfr.rs
+++ b/rawler/src/decoders/tfr.rs
@@ -24,7 +24,7 @@ impl<'a> TfrDecoder<'a> {
 }
 
 impl<'a> Decoder for TfrDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let camera = self.rawloader.check_supported(&self.tiff)?;
     let raw = fetch_ifd!(&self.tiff, TiffRootTag::WhiteLevel);
     let width = fetch_tag!(raw, TiffRootTag::ImageWidth).get_usize(0);

--- a/rawler/src/decoders/x3f.rs
+++ b/rawler/src/decoders/x3f.rs
@@ -108,7 +108,7 @@ impl<'a> X3fDecoder<'a> {
 }
 
 impl<'a> Decoder for X3fDecoder<'a> {
-  fn raw_image(&self, dummy: bool) -> Result<RawImage,String> {
+  fn raw_image(&self, _params: RawDecodeParams, dummy: bool) -> Result<RawImage,String> {
     let caminfo = self.dir.images
         .iter()
         .find(|i| i.typ == 2 && i.format == 0x12)

--- a/rawler/src/decompressors/crx/decoder.rs
+++ b/rawler/src/decompressors/crx/decoder.rs
@@ -5,157 +5,42 @@
 // Rewritten in Rust by Daniel Vogelbacher, based on logic found in
 // crx.cpp and documentation done by Laurent Clévy (https://github.com/lclevy/canon_cr3).
 
-use bitstream_io::BitReader;
-use log::debug;
-use rayon::prelude::*;
-use std::{io::Cursor, time::Instant};
-
-use crate::decompressors::crx::{idwt::WaveletTransform, mdat::parse_header, rice::RiceDecoder};
-
 use super::{
   mdat::{Plane, Tile},
   BandParam, CodecParams, CrxError, Result,
 };
+use crate::decompressors::crx::{idwt::WaveletTransform, mdat::parse_header, rice::RiceDecoder};
+use bitstream_io::BitReader;
+use itertools::izip;
+use log::debug;
+use rayon::prelude::*;
+use std::{convert::TryInto, io::Cursor, time::Instant};
 
 /// Maximum value for K during Adaptive Golomb-Rice for K prediction
 pub(super) const PREDICT_K_MAX: u32 = 15;
 pub(super) const PREDICT_K_ESCAPE: u32 = 41;
 pub(super) const PREDICT_K_ESCBITS: u32 = 21;
 
-impl CodecParams {
-  /// Decode MDAT section into a single CFA image
-  ///
-  /// Decoding processes all planes in all tiles and assembles the
-  /// decoded planes into proper tile output position and CFA pattern.
-  pub fn decode(mut self, mdat: &[u8]) -> Result<Vec<u16>> {
-    // Build nested Tiles/Planes/Bands
-    let mut tiles = parse_header(self.get_header(mdat))?;
-    self.process_tiles(&mut tiles);
-    for tile in tiles.iter_mut() {
-      tile.generate_qstep_table(&self, self.get_data(mdat))?;
-    }
+struct PlaneLineIter<'a> {
+  tile: &'a Tile,
+  plane: &'a Plane,
+  codec: CodecParams,
+  params: Vec<BandParam<'a>>,
+  iwt_transforms: Vec<WaveletTransform>,
+  //plane_buf: Vec<i32>,
+  next_row: usize,
+}
 
-    // cfa output is of final resolution
-    let mut cfa: Vec<u16> = vec![0; self.resolution()];
-
-    // Iterator over all planes
-    let plane_iter = tiles.par_iter().enumerate().flat_map(|(tile_id, tile)| {
-      tile
-        .planes
-        .par_iter()
-        .enumerate()
-        .map(move |(plane_id, plane)| (tile_id, tile, plane_id, plane))
-    });
-
-    let bufs: Vec<(usize, usize, Result<Vec<u16>>)> = plane_iter
-      .map(|(tile_id, tile, plane_id, plane)| (tile_id, plane_id, self.decode_plane(tile, plane, mdat)))
-      .collect();
-
-    // Integrate planes into final CFA
-    let instant = Instant::now();
-    for (tile_id, plane_id, buf) in bufs {
-      let plane_buf = buf.unwrap();
-      //debug!("BUF: tile: {} plane: {}", tile_id, plane_id);
-      assert_eq!(plane_buf.len(), (tiles[tile_id].plane_height * tiles[tile_id].plane_width) as usize);
-      self.integrate_cfa(&tiles, &mut cfa, tile_id, plane_id, &plane_buf)?;
-    }
-    debug!("CFA build: {} s", instant.elapsed().as_secs_f32());
-    Ok(cfa)
-  }
-
-  /// Decode a single plane
-  ///
-  /// A plane is a monochrome image, a CFA image raw has
-  /// normally 4 planes for R G1 G2 B or some other CFA pattern.
-  pub fn decode_plane(&self, tile: &Tile, plane: &Plane, mdat: &[u8]) -> Result<Vec<u16>> {
-    if self.levels > 0 {
-      self.decode_plane_lossy(tile, plane, mdat)
-    } else {
-      self.decode_plane_lossess(tile, plane, mdat)
-    }
-  }
-
-  /// Decode a single plane
-  ///
-  /// A plane is a monochrome image, a CFA image raw has
-  /// normally 4 planes for R G1 G2 B or some other CFA pattern.
-  pub fn decode_plane_lossess(&self, tile: &Tile, plane: &Plane, mdat: &[u8]) -> Result<Vec<u16>> {
+impl<'a> PlaneLineIter<'a> {
+  /// Create a new PlaneLine iterator for decoding
+  fn new(codec: CodecParams, tile: &'a Tile, plane: &'a Plane, mdat: &'a [u8]) -> Result<Self> {
     // Some checks for correct input
     assert!(tile.plane_height > 0);
     assert!(tile.plane_width > 0);
 
     // Reference to data section in MDAT
     // All calculated offsets are relative to the data section.
-    let data = self.get_data(mdat);
-
-    // Plane decoder returns a vector of exactly the size
-    // of a plane (w*h).
-    let mut plane_buf = vec![0; (tile.plane_height * tile.plane_width) as usize];
-
-    let plane_mdat_offset =
-      tile.data_offset + tile.qp_data.as_ref().map(|qp| qp.mdat_qp_data_size + qp.mdat_extra_size as u32).unwrap_or(0) as usize + plane.data_offset;
-
-    let i = 0;
-
-    let band = &plane.subbands.get(i).ok_or(CrxError::General(format!("Subband {} not found", i)))?;
-    let band_mdat_offset = plane_mdat_offset + band.data_offset;
-    //println!("band mdat offset: {}", band_mdat_offset);
-    let band_buf = &data[band_mdat_offset..band_mdat_offset + band.data_size];
-
-    // Line length is subband + one additional pixel at start end end
-    let line_len = 1 + band.width + 1;
-
-    let bitpump = BitReader::endian(Cursor::new(band_buf), bitstream_io::BigEndian);
-
-    let line_buf = [vec![0; line_len], vec![0; line_len]];
-    let line_k = Vec::new(); // lossless decoding needs no K buffer
-
-    let mut param = BandParam {
-      subband_width: band.width,
-      subband_height: band.height,
-      rounded_bits_mask: if plane.support_partial && i == 0 { plane.rounded_bits_mask } else { 0 },
-      rounded_bits: 0,
-      cur_line: 0,
-      line_buf,
-      line_k,
-      line_pos: 0,
-      line_len,
-      s_param: 0,
-      q_param: band.q_param,
-      supports_partial: if plane.support_partial && i == 0 { true } else { false }, // TODO: only for subbandnum == 0
-      rice: RiceDecoder::new(bitpump),
-    };
-
-    //debug!("Param: {:?}", param);
-
-    //println!("band height: {}", band.height);
-    for i in 0..band.height {
-      self.decode_line(&mut param)?;
-      assert_eq!(param.decoded_buf().len(), param.subband_width as usize);
-      self.convert_plane_line(param.decoded_buf(), &mut plane_buf[(i * band.width)..]);
-    }
-
-    assert_eq!(plane_buf.len(), (tile.plane_height * tile.plane_width) as usize);
-
-    Ok(plane_buf)
-  }
-
-  /// Decode a single plane
-  ///
-  /// A plane is a monochrome image, a CFA image raw has
-  /// normally 4 planes for R G1 G2 B or some other CFA pattern.
-  pub fn decode_plane_lossy(&self, tile: &Tile, plane: &Plane, mdat: &[u8]) -> Result<Vec<u16>> {
-    // Some checks for correct input
-    assert!(tile.plane_height > 0);
-    assert!(tile.plane_width > 0);
-
-    // Reference to data section in MDAT
-    // All calculated offsets are relative to the data section.
-    let data = self.get_data(mdat);
-
-    // Plane decoder returns a vector of exactly the size
-    // of a plane (w*h).
-    let mut plane_buf = vec![0; (tile.plane_height * tile.plane_width) as usize];
+    let data = codec.get_data(mdat);
 
     let plane_mdat_offset =
       tile.data_offset + tile.qp_data.as_ref().map(|qp| qp.mdat_qp_data_size + qp.mdat_extra_size as u32).unwrap_or(0) as usize + plane.data_offset;
@@ -163,12 +48,10 @@ impl CodecParams {
     let mut params = Vec::with_capacity(plane.subbands.len());
     for (band_id, band) in plane.subbands.iter().enumerate() {
       let band_mdat_offset = plane_mdat_offset + band.data_offset;
-      //println!("band mdat offset: {}", band_mdat_offset);
+      debug!("Band {} has MDAT offset: {}", band_id, band_mdat_offset);
       let band_buf = &data[band_mdat_offset..band_mdat_offset + band.data_size];
-
-      // Line length is subband + one additional pixel at start end end
+      // Line length is subband + one additional pixel at start and end
       let line_len = 1 + band.width + 1;
-
       let bitpump = BitReader::endian(Cursor::new(band_buf), bitstream_io::BigEndian);
 
       let param = BandParam {
@@ -189,33 +72,146 @@ impl CodecParams {
       params.push(param);
     }
 
-    let mut iwt_transforms = Vec::with_capacity(self.levels);
-    for level in 0..self.levels {
-      let band = 3 * level + 1;
-      let (height, width) = if level >= self.levels - 1 {
-        (tile.plane_height, tile.plane_width)
+    let mut iwt_transforms = Vec::with_capacity(codec.levels);
+
+    if codec.levels > 0 {
+      // create Wavelet transforms
+      for level in 0..codec.levels {
+        let band = 3 * level + 1;
+        let (height, width) = if level >= codec.levels - 1 {
+          (tile.plane_height, tile.plane_width)
+        } else {
+          (plane.subbands[band + 3].height, plane.subbands[band + 4].width)
+        };
+        iwt_transforms.push(WaveletTransform::new(height, width));
+      }
+      codec.idwt_53_filter_init(tile, plane, &mut params, &mut iwt_transforms, codec.levels)?;
+    }
+
+    Ok(Self {
+      params,
+      tile,
+      plane,
+      codec,
+      iwt_transforms,
+      next_row: 0,
+    })
+  }
+
+  /// Decode a single line from plane
+  fn decode_plane_line(&mut self) -> Result<&[i32]> {
+    if self.next_row < self.tile.plane_height {
+      self.next_row += 1;
+      if self.codec.levels > 0 {
+        self
+          .codec
+          .idwt_53_filter_decode(self.tile, self.plane, &mut self.params, &mut self.iwt_transforms, self.codec.levels - 1)?;
+        self
+          .codec
+          .idwt_53_filter_transform(self.tile, self.plane, &mut self.params, &mut self.iwt_transforms, self.codec.levels - 1)?;
+        let line_data = self.iwt_transforms[self.codec.levels - 1].getline();
+        assert_eq!(line_data.len(), self.tile.plane_width);
+        Ok(line_data)
       } else {
-        (plane.subbands[band + 3].height, plane.subbands[band + 4].width)
-      };
-      //println!("band width: {}", width);
-      iwt_transforms.push(WaveletTransform::new(height, width));
+        assert_eq!(self.plane.subbands.len(), 1);
+        let param = &mut self.params[0];
+        self.codec.decode_line(param)?;
+        let line_data = param.decoded_buf();
+        assert_eq!(line_data.len(), param.subband_width as usize);
+        assert_eq!(line_data.len(), self.tile.plane_width);
+        Ok(line_data)
+      }
+    } else {
+      Err(CrxError::General(format!("All rows processed, can't decode more")))
+    }
+  }
+}
+
+/// Iterator over a plane, returning on each call a new decoded line
+impl<'a> Iterator for PlaneLineIter<'a> {
+  type Item = Result<PlaneLine>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.next_row < self.tile.plane_height {
+      match self.decode_plane_line() {
+        Ok(line) => Some(Ok(line.into())),
+        Err(e) => Some(Err(e)),
+      }
+    } else {
+      None
+    }
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    (0, Some(self.tile.plane_height))
+  }
+}
+
+/// A plane line is a vector if i32 values
+type PlaneLine = Vec<i32>;
+
+/// Wrapper for PlaneLineIter
+/// Decodes a complete plane and returns it as vector of lines
+fn decode_full_plane(codec: &CodecParams, tile: &Tile, plane: &Plane, mdat: &[u8]) -> Result<Vec<PlaneLine>> {
+  //eprintln!("Process tile {}, plane: {}", tile.id, plane.id);
+  let line_decoder = PlaneLineIter::new(codec.clone(), tile, plane, mdat)?;
+  line_decoder.collect()
+}
+
+impl CodecParams {
+  /// Decode MDAT section into a single CFA image
+  ///
+  /// Decoding processes all planes in all tiles and assembles the
+  /// decoded planes into proper tile output position and CFA pattern.
+  pub fn decode(mut self, mdat: &[u8]) -> Result<Vec<u16>> {
+    let instant = Instant::now();
+    debug!("Tile configuration: rows: {}, columns: {}", self.tile_rows, self.tile_cols);
+    // Build nested Tiles/Planes/Bands
+    let mut tiles = parse_header(self.get_header(mdat))?;
+    self.process_tiles(&mut tiles);
+    for tile in tiles.iter_mut() {
+      tile.generate_qstep_table(&self, self.get_data(mdat))?;
     }
 
-    self.idwt_53_filter_init(tile, plane, &mut params, &mut iwt_transforms, self.levels)?;
+    // cfa output is of final resolution
+    let mut cfa: Vec<u16> = vec![0; self.resolution()];
 
-    for i in 0..tile.plane_height {
-      self.idwt_53_filter_decode(tile, plane, &mut params, &mut iwt_transforms, self.levels - 1)?;
-      self.idwt_53_filter_transform(tile, plane, &mut params, &mut iwt_transforms, self.levels - 1)?;
+    // Combine all tiles and planes into parallel iterators
+    // and decode the full planes.
+    let plane_bufs: Result<Vec<Vec<Vec<PlaneLine>>>> = tiles
+      .par_iter()
+      .map(|tile| tile.planes.par_iter().map(move |plane| decode_full_plane(&self, tile, plane, mdat)).collect())
+      .collect();
 
-      let line_data = iwt_transforms[self.levels - 1].getline();
-
-      assert_eq!(line_data.len(), tile.plane_width);
-      self.convert_plane_line(line_data, &mut plane_buf[(i * tile.plane_width)..]);
+    // Now we have a list of tiles->planes->plane-lines
+    // and can combine them to the final CFA
+    match plane_bufs {
+      Ok(bufs) => {
+        for (tile_id, tile) in bufs.into_iter().enumerate() {
+          let plane_count = tile.len();
+          assert_eq!(plane_count, 4);
+          // Convert vector of planes to excact count of 4 planes - or fail
+          let planes: [Vec<PlaneLine>; 4] = tile
+            .try_into()
+            .map_err(|_| CrxError::General(format!("Invalid plane count {} (expected 4) for tile {}", plane_count, tile_id)))?;
+          // References to all 4 plane buffers
+          let (p0, p1, p2, p3) = (&planes[0], &planes[1], &planes[2], &planes[3]);
+          // Process each PlaneLine in all 4 buffers
+          for (plane_row, (l0, l1, l2, l3)) in izip!(p0, p1, p2, p3).enumerate() {
+            let (c0, c1, c2, c3) = convert_plane_line(&self, &l0, &l1, &l2, &l3)?;
+            integrate_cfa(&self, &tiles, &mut cfa, tile_id, 0, plane_row, &c0)?;
+            integrate_cfa(&self, &tiles, &mut cfa, tile_id, 1, plane_row, &c1)?;
+            integrate_cfa(&self, &tiles, &mut cfa, tile_id, 2, plane_row, &c2)?;
+            integrate_cfa(&self, &tiles, &mut cfa, tile_id, 3, plane_row, &c3)?;
+          }
+        }
+      }
+      Err(e) => {
+        return Err(e);
+      }
     }
-
-    assert_eq!(plane_buf.len(), (tile.plane_height * tile.plane_width) as usize);
-
-    Ok(plane_buf)
+    debug!("MDAT decoding and CFA build: {} s", instant.elapsed().as_secs_f32());
+    Ok(cfa)
   }
 
   /// Decode top line without a previous K buffer
@@ -235,7 +231,7 @@ impl CodecParams {
       } else {
         //println!("coeff {} = 0", p.coeff_a());
         if p.rice.bitstream_get_bits(1)? == 1 {
-          let n_syms = self.symbol_run_count(p, remaining).unwrap();
+          let n_syms = self.symbol_run_count(p, remaining)?;
           //println!("found {} syms", n_syms);
           remaining = remaining.saturating_sub(n_syms);
           // copy symbol n_syms times
@@ -292,7 +288,7 @@ impl CodecParams {
       } else {
         if p.rice.bitstream_get_bits(1)? == 1 {
           assert!(remaining != 1);
-          let n_syms = self.symbol_run_count(p, remaining).unwrap();
+          let n_syms = self.symbol_run_count(p, remaining)?;
 
           remaining = remaining.saturating_sub(n_syms);
           // copy symbol n_syms times
@@ -610,7 +606,7 @@ impl CodecParams {
     } else if !param.supports_partial {
       // Swap line buffers so previous decoded (1) is now above (0)
       param.line_buf.swap(0, 1);
-      self.decode_nontop_line_no_ref_prev_line(param).unwrap();
+      self.decode_nontop_line_no_ref_prev_line(param)?;
     } else if param.rounded_bits_mask <= 0 {
       // Swap line buffers so previous decoded (1) is now above (0)
       param.line_buf.swap(0, 1);
@@ -621,75 +617,6 @@ impl CodecParams {
       self.decode_nontop_line_rounded(param)?;
     }
     param.cur_line += 1;
-    Ok(())
-  }
-
-  /// Convert a decoded line to plane output
-  /// Results from decode_line() are signed 32 bit integers.
-  /// By using a median and max value, these are converted
-  /// to unsigned 16 bit integers.
-  fn convert_plane_line(&self, line: &[i32], plane_buf: &mut [u16]) {
-    assert_eq!(self.enc_type, 0);
-    assert_eq!(self.plane_count, 4);
-    let median: i32 = 1 << (self.n_bits - 1);
-    let max_val: i32 = (1 << self.n_bits) - 1;
-    for (i, v) in line.iter().enumerate() {
-      plane_buf[i] = constrain(median + v, 0, max_val) as u16
-    }
-  }
-
-  /// Integrate a plane buffer into CFA output image
-  ///
-  /// A plane is a single monochrome image for one of the four CFA colors.
-  /// `plane_id` is 0, 1, 2 or 3 for R, G1, G2, B
-  fn integrate_cfa(&self, tiles: &Vec<Tile>, cfa_buf: &mut [u16], tile_id: usize, plane_id: usize, plane_buf: &[u16]) -> Result<()> {
-    // 2x2 pixel for RGGB
-    const CFA_DIM: usize = 2;
-
-    assert_ne!(plane_buf.len(), 0);
-    assert_ne!(cfa_buf.len(), 0);
-    assert!(self.tile_cols > 0);
-    assert!(self.tile_rows > 0);
-
-    if plane_id > 3 {
-      return Err(CrxError::Overflow(format!(
-        "More then 4 planes detected, unable to process plane_id {}",
-        plane_id
-      )));
-    }
-
-    let tile_row_idx = tile_id / self.tile_cols; // round down
-    let tile_col_idx = tile_id % self.tile_cols; // round down
-
-    // Offset from top
-    let row_offset = tile_row_idx * self.tile_width;
-
-    // Offset from left
-    let col_offset = tile_col_idx * self.tile_width;
-
-    let (row_shift, col_shift) = match plane_id {
-      0 => (0, 0),
-      1 => (0, 1),
-      2 => (1, 0),
-      3 => (1, 1),
-      _ => {
-        return Err(CrxError::General(format!("Invalid plane id")));
-      }
-    };
-
-    for plane_row in 0..tiles[tile_id].plane_height {
-      // Row index into CFA for untiled full area
-      let row_idx = row_offset + (plane_row * CFA_DIM) + row_shift;
-
-      for plane_col in 0..tiles[tile_id].plane_width {
-        // Row index into CFA for untiled full area
-        let col_idx = col_offset + (plane_col * CFA_DIM) + col_shift;
-
-        // Copy from plane to CFA
-        cfa_buf[(row_idx * self.image_width) + col_idx] = plane_buf[plane_row * tiles[tile_id].plane_width + plane_col];
-      }
-    }
-
     Ok(())
   }
 }
@@ -731,4 +658,107 @@ pub(super) fn med(a: i32, b: i32, c: i32) -> i32 {
   } else {
     a + b - c // no edge detected
   }
+}
+
+/// Convert a decoded line to plane output
+/// Results from decode_line() are signed 32 bit integers.
+/// By using a median and max value, these are converted
+/// to unsigned 16 bit integers.
+fn convert_plane_line(codec: &CodecParams, l0: &[i32], l1: &[i32], l2: &[i32], l3: &[i32]) -> Result<(Vec<u16>, Vec<u16>, Vec<u16>, Vec<u16>)> {
+  let mut p0 = vec![0; l0.len()];
+  let mut p1 = vec![0; l1.len()];
+  let mut p2 = vec![0; l2.len()];
+  let mut p3 = vec![0; l3.len()];
+
+  match codec.enc_type {
+    0 => {
+      let median: i32 = 1 << (codec.n_bits - 1);
+      let max_val: i32 = (1 << codec.n_bits) - 1;
+
+      izip!(l0, l1, l2, l3).enumerate().for_each(|(i, (v0, v1, v2, v3))| {
+        p0[i] = constrain(median + v0, 0, max_val) as u16;
+        p1[i] = constrain(median + v1, 0, max_val) as u16;
+        p2[i] = constrain(median + v2, 0, max_val) as u16;
+        p3[i] = constrain(median + v3, 0, max_val) as u16;
+      });
+    }
+    3 => {
+      let median: i32 = 1 << (codec.n_bits - 1) << 10;
+      let max_val: i32 = (1 << codec.n_bits) - 1;
+
+      izip!(l0, l1, l2, l3).enumerate().for_each(|(i, (v0, v1, v2, v3))| {
+        let mut gr: i32 = median + (v0 << 10) - 168 * v1 - 585 * v3;
+        if gr < 0 {
+          gr = -(((gr.abs() + 512) >> 9) & !1);
+        } else {
+          gr = ((gr.abs() + 512) >> 9) & !1;
+        }
+        p0[i] = constrain((median + (v0 << 10) + 1510 * v3 + 512) >> 10, 0, max_val) as u16;
+        p1[i] = constrain((v2 + gr + 1) >> 1, 0, max_val) as u16;
+        p2[i] = constrain((gr - v2 + 1) >> 1, 0, max_val) as u16;
+        p3[i] = constrain((median + (v0 << 10) + 1927 * v1 + 512) >> 10, 0, max_val) as u16;
+      });
+    }
+    enc_type @ _ => {
+      return Err(CrxError::General(format!("Unsupported encoding type {}", enc_type)));
+    }
+  }
+
+  Ok((p0, p1, p2, p3))
+}
+
+/// Integrate a plane buffer into CFA output image
+///
+/// A plane is a single monochrome image for one of the four CFA colors.
+/// `plane_id` is 0, 1, 2 or 3 for R, G1, G2, B
+fn integrate_cfa(
+  codec: &CodecParams,
+  tiles: &Vec<Tile>,
+  cfa_buf: &mut [u16],
+  tile_id: usize,
+  plane_id: usize,
+  plane_row: usize,
+  plane_buf: &[u16],
+) -> Result<()> {
+  // 2x2 pixel for RGGB
+  const CFA_DIM: usize = 2;
+
+  assert_ne!(plane_buf.len(), 0);
+  assert_ne!(cfa_buf.len(), 0);
+  assert!(codec.tile_cols > 0);
+  assert!(codec.tile_rows > 0);
+
+  if plane_id > 3 {
+    return Err(CrxError::Overflow(format!(
+      "More then 4 planes detected, unable to process plane_id {}",
+      plane_id
+    )));
+  }
+
+  let tile_row_idx = tile_id / codec.tile_cols; // round down
+  let tile_col_idx = tile_id % codec.tile_cols; // round down
+
+  // Offset from top
+  let row_offset = tile_row_idx * codec.tile_width;
+  // Offset from left
+  let col_offset = tile_col_idx * codec.tile_width;
+  let (row_shift, col_shift) = match plane_id {
+    0 => (0, 0),
+    1 => (0, 1),
+    2 => (1, 0),
+    3 => (1, 1),
+    _ => {
+      return Err(CrxError::General(format!("Invalid plane id")));
+    }
+  };
+  //println!("plane_width: {}, buf_size: {}", tiles[tile_id].plane_width, plane_buf.len());
+  let row_idx = row_offset + (plane_row * CFA_DIM) + row_shift;
+  for plane_col in 0..tiles[tile_id].plane_width {
+    // Row index into CFA for untiled full area
+    let col_idx = col_offset + (plane_col * CFA_DIM) + col_shift;
+
+    // Copy from plane to CFA
+    cfa_buf[(row_idx * codec.image_width) + col_idx] = plane_buf[plane_col];
+  }
+  Ok(())
 }

--- a/rawler/src/decompressors/crx/iquant.rs
+++ b/rawler/src/decompressors/crx/iquant.rs
@@ -12,6 +12,7 @@ use super::{
 };
 use crate::decompressors::crx::{decoder::error_code_signed, rice::RiceDecoder};
 use bitstream_io::BitReader;
+use log::warn;
 use std::io::Cursor;
 
 /// QStep table for QP [0,1,2,3,4,5]
@@ -41,6 +42,7 @@ impl CodecParams {
   /// Update Q parameter.
   /// Seems not to be used in real world (untested).
   pub(super) fn update_q_param(_band: &Subband, param: &mut BandParam) -> Result<()> {
+    warn!("Untested routine, please send in a sample file");
     let bit_code = param.rice.adaptive_rice_decode(true, 23, 8, 0)?;
     param.q_param = ((param.q_param as i32) + error_code_signed(bit_code)) as u32;
     if param.rice.k() > 7 {
@@ -203,7 +205,7 @@ impl Tile {
           q_steps.push(q_step);
         }
         _ => {
-          panic!("Unsupported level while generating qstep data: {}", level);
+          return Err(CrxError::General(format!("Unsupported level while generating qstep data: {}", level)));
         }
       }
     }

--- a/rawler/src/lib.rs
+++ b/rawler/src/lib.rs
@@ -48,6 +48,7 @@
 
 
   use decoders::Decoder;
+use decoders::RawDecodeParams;
 use lazy_static::lazy_static;
 
   pub mod bits;
@@ -135,8 +136,8 @@ pub mod analyze;
   ///   Err(e) => ... some appropriate action when the file is unreadable ...
   /// };
   /// ```
-  pub fn decode(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
-    LOADER.decode(reader, false).map_err(|err| RawLoaderError::new(err))
+  pub fn decode(reader: &mut dyn Read, params: RawDecodeParams) -> Result<RawImage,RawLoaderError> {
+    LOADER.decode(reader, params, false).map_err(|err| RawLoaderError::new(err))
   }
 
   // Used to force lazy_static initializations. Useful for fuzzing.
@@ -155,10 +156,14 @@ pub mod analyze;
   // Used for fuzzing everything but the decoders themselves
   #[doc(hidden)]
   pub fn decode_dummy(reader: &mut dyn Read) -> Result<RawImage,RawLoaderError> {
-    LOADER.decode(reader, true).map_err(|err| RawLoaderError::new(err))
+    LOADER.decode(reader, RawDecodeParams::default(), true).map_err(|err| RawLoaderError::new(err))
   }
 
 
   pub fn get_decoder<'b>(buf: &'b Buffer) -> Result<Box<dyn Decoder + 'b>, RawLoaderError> {
     LOADER.get_decoder(buf).map_err(|err| RawLoaderError::new(err))
+  }
+
+  pub fn raw_image_count_file<P: AsRef<Path>>(path: P) -> Result<usize,RawLoaderError> {
+    LOADER.raw_image_count_file(path.as_ref()).map_err(|err| RawLoaderError::new(err))
   }

--- a/rawler/tests/cameras.rs
+++ b/rawler/tests/cameras.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "samplecheck")]
 mod camera_samples {
 
-  use rawler::analyze::{analyze_file, extract_raw_pixels, raw_as_pgm, AnalyzerResult};
+  use rawler::{analyze::{analyze_file, extract_raw_pixels, raw_as_pgm, AnalyzerResult}, decoders::RawDecodeParams};
   use std::{cmp::Ordering, io::Cursor, path::PathBuf};
 
   macro_rules! camera_file_check {
@@ -74,6 +74,7 @@ mod camera_samples {
 
   camera_file_check!("Canon", "PowerShot G5 X Mark II", canon_powershot_g5x_mark2_raw_nocrop_nodual, "Canon PowerShot G5 X Mark II_RAW_ISO_200_nocrop_nodual.CR3.raw");
   camera_file_check!("Canon", "PowerShot G5 X Mark II", canon_powershot_g5x_mark2_craw_nocrop_nodual, "Canon PowerShot G5 X Mark II_CRAW_ISO_200_nocrop_nodual.CR3.raw");
+  camera_file_check!("Canon", "PowerShot G5 X Mark II", canon_powershot_g5x_mark2_filmroll_nocrop_nodual, "Canon PowerShot G5 X Mark II_FILMROLL_ISO_200_nocrop_nodual.CR3.raw");
 
   camera_file_check!("Canon", "PowerShot G7 X Mark III", canon_powershot_g7x_mark3_raw_nocrop_nodual, "Canon PowerShot G7 X Mark III_RAW_ISO_200_nocrop_nodual.CR3.raw");
   camera_file_check!("Canon", "PowerShot G7 X Mark III", canon_powershot_g7x_mark3_craw_nocrop_nodual, "Canon PowerShot G7 X Mark III_CRAW_ISO_200_nocrop_nodual.CR3.raw");
@@ -98,7 +99,7 @@ mod camera_samples {
     assert_eq!(old_stats, new_stats);
 
     // Validate pixel data
-    let (width, height, buf) = extract_raw_pixels(&raw_file).unwrap();
+    let (width, height, buf) = extract_raw_pixels(&raw_file, RawDecodeParams::default()).unwrap();
     let mut new_pgm = Vec::new();
     raw_as_pgm(width, height, &buf, &mut Cursor::new(&mut new_pgm))?;
     let old_pgm = std::fs::read(&pixel_file)?;


### PR DESCRIPTION
Roll files uses enc_type 3. This PR add support for enc_type 3 and introduce a new cmd line parameter **--image-index** to select a specific image.

fixes #50 