### PR TITLE
Add EF100-400mm L II and Tamron 90mm macro lenses

### DIFF
--- a/rawler/data/lenses.toml
+++ b/rawler/data/lenses.toml
@@ -271,7 +271,7 @@ aperture_range = [[28, 10], [40, 10]]
 # Venus Optics/Laowa lenses
 [[lenses]]
 key = "LAOWA 100mm F2.8 CA-Dreamer Macro 2x"
-model = "100mm F2.8 2X Ultra Macro APO"
-make = "Venus Laowa"
+model = "Laowa 100mm F2.8 2X Ultra Macro APO"
+make = "Venus"
 focal_range = [[100, 1], [100, 1]]
 aperture_range = [[28, 10], [28, 10]]

--- a/rawler/data/lenses.toml
+++ b/rawler/data/lenses.toml
@@ -156,6 +156,13 @@ model = "EF 50mm f/1.4 USM"
 focal_range = [[50, 1], [50, 1]]
 aperture_range = [[14, 10], [14, 10]]
 
+[[lenses]]
+key = "EF100-400mm f/4.5-5.6L IS II USM"
+make = "Canon"
+model = "EF100-400mm f/4.5-5.6L IS II USM"
+focal_range = [[100, 1], [400, 1]]
+aperture_range = [[45, 10], [56, 10]]
+
 # Canon EF-S mount lenses
 
 [[lenses]]
@@ -240,3 +247,11 @@ make = "Sigma"
 model = "50mm f/1.4 DG HSM | A"
 focal_range = [[50, 1], [50, 1]]
 aperture_range = [[14, 10], [14, 10]]
+
+# Tamron lenses
+[[lenses]]
+key = "TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004"
+make = "TAMRON"
+model = "TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004"
+focal_range = [[90, 1], [90, 1]]
+aperture_range = [[28, 10], [28, 10]]

--- a/rawler/data/lenses.toml
+++ b/rawler/data/lenses.toml
@@ -255,3 +255,11 @@ make = "TAMRON"
 model = "TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004"
 focal_range = [[90, 1], [90, 1]]
 aperture_range = [[28, 10], [28, 10]]
+
+# Venus Optics/Laowa lenses
+[[lenses]]
+key = "LAOWA 100mm F2.8 CA-Dreamer Macro 2x"
+make = "Venus Optics Laowa"
+model = "Laowa 100mm F2.8 CA-Dreamer Macro 2x"
+focal_range = [[100, 1], [100, 1]]
+aperture_range = [[28, 10], [28, 10]]

--- a/rawler/data/lenses.toml
+++ b/rawler/data/lenses.toml
@@ -159,7 +159,7 @@ aperture_range = [[14, 10], [14, 10]]
 [[lenses]]
 key = "EF100-400mm f/4.5-5.6L IS II USM"
 make = "Canon"
-model = "EF100-400mm f/4.5-5.6L IS II USM"
+model = "EF 100-400mm f/4.5-5.6L IS II USM"
 focal_range = [[100, 1], [400, 1]]
 aperture_range = [[45, 10], [56, 10]]
 
@@ -232,14 +232,12 @@ model = "150-600mm f/5-6.3 DG OS HSM | S"
 focal_range = [[150, 1], [600, 1]]
 aperture_range = [[50, 10], [63, 10]]
 
-
 [[lenses]]
 key = "30mm F1.4 DC HSM | Art 013"
 make = "Sigma"
 model = "30mm f/1.4 DC HSM | A"
 focal_range = [[30, 1], [30, 1]]
 aperture_range = [[14, 10], [14, 10]]
-
 
 [[lenses]]
 key = "50mm F1.4 DG HSM | Art 014"
@@ -251,15 +249,29 @@ aperture_range = [[14, 10], [14, 10]]
 # Tamron lenses
 [[lenses]]
 key = "TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004"
-make = "TAMRON"
-model = "TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004"
+make = "Tamron"
+model = "SP 90mm F/2.8 Di VC USD Macro 1:1 F004"
 focal_range = [[90, 1], [90, 1]]
 aperture_range = [[28, 10], [28, 10]]
+
+[[lenses]]
+key = "TAMRON 10-24mm F/3.5-4.5 Di II VC HLD B023"
+make = "Tamron"
+model = "10-24mm f/3.5-4.5 Di II VC HLD (B023)"
+focal_range = [[10, 1], [24, 1]]
+aperture_range = [[35, 10], [45, 10]]
+
+[[lenses]]
+key = "TAMRON 17-35mm F/2.8-4 Di OSD A037"
+model = "17-35mm F/2.8-4 Di OSD A037"
+make = "Tamron"
+focal_range = [[17, 1], [35, 1]]
+aperture_range = [[28, 10], [40, 10]]
 
 # Venus Optics/Laowa lenses
 [[lenses]]
 key = "LAOWA 100mm F2.8 CA-Dreamer Macro 2x"
-make = "Venus Optics Laowa"
-model = "Laowa 100mm F2.8 CA-Dreamer Macro 2x"
+model = "100mm F2.8 2X Ultra Macro APO"
+make = "Venus Laowa"
 focal_range = [[100, 1], [100, 1]]
 aperture_range = [[28, 10], [28, 10]]


### PR DESCRIPTION
Hello, and thanks for a fantastic tool. I've added some lens definitions for lenses I use. The "key" is taken from the error notice of dnglab, and confirmed to match the "lens model" field from exiv2 -pa and exiftool (example below).

I'm unable to compile DNGlab on debian due to an error (below), so haven't been able to test this change locally. i'm using rust from debian's repos, rustc version 1.48.

dnglab v0.1.0rc5 output on Canon R5 images with new lenses:
```
Unknown lens model: 'TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004'. Please open an issue at https://github.com/dnglab/dnglab/issues and provide the RAW file
Unknown lens model: 'EF100-400mm f/4.5-5.6L IS II USM'. Please open an issue at https://github.com/dnglab/dnglab/issues and provide the RAW file
Unknown lens model: 'TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004'. Please open an issue at https://github.com/dnglab/dnglab/issues and provide the RAW file
Unknown lens model: 'EF100-400mm f/4.5-5.6L IS II USM'. Please open an issue at https://github.com/dnglab/dnglab/issues and provide the RAW file
Unknown lens model: 'TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004'. Please open an issue at https://github.com/dnglab/dnglab/issues and provide the RAW file
```


**EDIT: removed compile error traceback, resolved after updating to latest rustc**
