### PR TITLE
add support for canon eos kissm

### DIFF
--- a/rawler/data/cameras/canon/eos_kissm.toml
+++ b/rawler/data/cameras/canon/eos_kissm.toml
@@ -1,9 +1,0 @@
-make = "Canon"
-model = "Canon EOS KISS M"
-clean_make = "Canon"
-clean_model = "EOS KISS M"
-color_pattern = "RGGB"
-color_matrix = {D65 = [0.8532, -0.0701, -0.1167, -0.4095, 1.1879, 0.2508, -0.0797, 0.2424, 0.701]}
-wb_offset = 71
-bl_offset = 329
-wl_offset = 796

--- a/rawler/data/cameras/canon/eos_kissm.toml
+++ b/rawler/data/cameras/canon/eos_kissm.toml
@@ -1,0 +1,9 @@
+make = "Canon"
+model = "Canon EOS KISS M"
+clean_make = "Canon"
+clean_model = "EOS KISS M"
+color_pattern = "RGGB"
+color_matrix = {D65 = [0.8532, -0.0701, -0.1167, -0.4095, 1.1879, 0.2508, -0.0797, 0.2424, 0.701]}
+wb_offset = 71
+bl_offset = 329
+wl_offset = 796

--- a/rawler/data/cameras/canon/eos_m50.toml
+++ b/rawler/data/cameras/canon/eos_m50.toml
@@ -1,5 +1,8 @@
 make = "Canon"
 model = "Canon EOS M50"
+model_aliases = [
+  ["Canon EOS KISS M", "EOS KISS M"],
+]
 clean_make = "Canon"
 clean_model = "EOS M50"
 color_pattern = "RGGB"


### PR DESCRIPTION
Doesn't recognise the canon eos kiss-m, which is the Japanese branding of the canon eos m50 camera. Characteristics are the same as the m50, so create a data entry for the kiss-m with same parameters as m50.