### PR TITLE
Add SIMD (avx, avx2) optimizations for LJPEG92 encoder

### DIFF
--- a/bin/dnglab/src/dnggen.rs
+++ b/bin/dnglab/src/dnggen.rs
@@ -380,7 +380,7 @@ fn dng_put_raw_ljpeg(raw_ifd: &mut DirectoryWriter<'_, '_>, rawimage: &RawImage,
           //assert_eq!((tile_w * rawimage.cpp) % components, 0);
           //assert_eq!((tile_w * rawimage.cpp) % 2, 0);
           //assert_eq!(tile_h % 2, 0);
-          let state = LjpegCompressor::new(tile, j_width * realign, j_height / realign, components, rawimage.bps as u8, predictor, 0).unwrap();
+          let state = LjpegCompressor::new(tile, j_width * realign, j_height / realign, components, rawimage.bps as u8, predictor, 0, 0).unwrap();
           state.encode().unwrap()
         })
         .collect();

--- a/rawler/Cargo.toml
+++ b/rawler/Cargo.toml
@@ -37,6 +37,7 @@ uuid = {version = "0.8", features = ["serde", "v4"]}
 tokio = { version = "1.11.0", features = ["full"] }
 async-trait = "0.1.51"
 futures = "0.3"
+multiversion = "0.6.1"
 
 [dev-dependencies]
 serde_yaml = "0.8"

--- a/rawler/benches/perf.rs
+++ b/rawler/benches/perf.rs
@@ -14,7 +14,7 @@ fn encode_ljpeg(img: &Vec<u16>, w: usize, h: usize, ncomp: usize) {
   let pred = 1;
   let bps = 16;
 
-  let state = LjpegCompressor::new(&img, w, h, ncomp, bps, pred, 0).unwrap();
+  let state = LjpegCompressor::new(&img, w, h, ncomp, bps, pred, 0, 0).unwrap();
   let _result = state.encode().unwrap();
 }
 


### PR DESCRIPTION
````
ljpeg-encoder/encode_3000x2000
	time:   [97.943 ms 98.145 ms 98.369 ms]
	change: [-28.387% -28.228% -28.076%] (p = 0.00 < 0.10)
````

This adds little bit of unsafe code.