### PR TITLE
Fix: LJPEG92 compression adjust_bits() routine

### DIFF
--- a/rawler/src/ljpeg92.rs
+++ b/rawler/src/ljpeg92.rs
@@ -391,7 +391,7 @@ impl HuffTableBuilder {
 
     while i > 16 {
       if self.bits[i] > 0 {
-        let mut j = i - 1;
+        let mut j = i - 2; // See K.3: J = I - 1; J  = J - 1;
         while self.bits[j] == 0 {
           j -= 1;
         }


### PR DESCRIPTION
In Section K.3, the integer j is decremented twice, which
can be combined but was totally ignored in current implementation.