### PR TITLE
For SubIFDs, we must ignore the initial sub_tags

### DIFF
--- a/rawler/src/formats/tiff/ifd.rs
+++ b/rawler/src/formats/tiff/ifd.rs
@@ -156,7 +156,7 @@ impl IFD {
     for subs in sub_ifd_offsets {
       let mut ifds = Vec::new();
       for offset in subs.1 {
-        match Self::new(reader, apply_corr(offset, corr), base, corr, endian, sub_tags) {
+        match Self::new(reader, apply_corr(offset, corr), base, corr, endian, &[]) {
           Ok(ifd) => ifds.push(ifd),
           Err(err) => {
             log::warn!("Error while processing TIFF sub-IFD for tag 0x{:X}, ignoring it: {}", subs.0, err);


### PR DESCRIPTION
The sub_tags parameter is only relevant for the current
IFD and it is unknown if the same tag but with different meaning
appears in any of the SubIFDs.