### PR TITLE
Reduce stack usage for CFA to prevent stack overflows

### DIFF
--- a/rawler/src/decoders/iiq.rs
+++ b/rawler/src/decoders/iiq.rs
@@ -490,7 +490,7 @@ impl<'a> IiqDecoder<'a> {
     let cfa = self
       .camera
       .cfa
-      .map_colors(|row, _col, color| if color == cfa::CFA_COLOR_G && (row & 1 == 1) { 3 } else { color });
+      .map_colors(|row, _col, color| if (color as usize) == cfa::CFA_COLOR_G && (row & 1 == 1) { 3 } else { color });
 
     for flat in senscorr.flats.iter() {
       let nc = match flat.typ {


### PR DESCRIPTION
Because of https://github.com/rust-lang/rust/issues/34283, in the
get_decoder() function we ran out of stack space.
Each CFA instance is ~19.000 bytes on the stack, and each decoder
instance contains a camera member which contains a cfa member.

This found by:

cargo +nightly rustc --lib -- -Zprint-type-sizes 2>&1 | grep print-type > type-sizes.txt
egrep "[[:digit:]]{5,9} bytes" type-sizes.txt