### PR TITLE
CR3: Read active area from metadata

### DIFF
--- a/bin/dnglab/src/dnggen.rs
+++ b/bin/dnglab/src/dnggen.rs
@@ -431,6 +431,9 @@ fn dng_put_raw(raw_ifd: &mut DirectoryWriter<'_, '_>, rawimage: &RawImage, param
     CropMode::None => full_size,
   };
 
+  assert!(active_area.p.x + active_area.d.w <= rawimage.width);
+  assert!(active_area.p.y + active_area.d.h <= rawimage.height);
+
   raw_ifd.add_tag(TiffCommonTag::NewSubFileType, 0_u16)?; // Raw
   raw_ifd.add_tag(TiffCommonTag::ImageWidth, rawimage.width as u32)?;
   raw_ifd.add_tag(TiffCommonTag::ImageLength, rawimage.height as u32)?;

--- a/rawler/data/testdata/cameras/Canon/EOS 250D/raw_modes/Canon EOS 250D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 250D/raw_modes/Canon EOS 250D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS 250D/raw_modes/Canon EOS 250D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 250D/raw_modes/Canon EOS 250D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS 850D/raw_modes/Canon EOS 850D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 850D/raw_modes/Canon EOS 850D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS 850D/raw_modes/Canon EOS 850D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 850D/raw_modes/Canon EOS 850D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS 90D/raw_modes/Canon EOS 90D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 90D/raw_modes/Canon EOS 90D_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4640
       activeArea:
         p:
-          x: 156
-          y: 84
+          x: 144
+          y: 72
         d:
-          w: 6960
-          h: 4640
+          w: 6982
+          h: 4658
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS 90D/raw_modes/Canon EOS 90D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS 90D/raw_modes/Canon EOS 90D_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4640
       activeArea:
         p:
-          x: 156
-          y: 84
+          x: 144
+          y: 72
         d:
-          w: 6960
-          h: 4640
+          w: 6982
+          h: 4658
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS M200/raw_modes/Canon EOS M200_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M200/raw_modes/Canon EOS M200_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS M200/raw_modes/Canon EOS M200_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M200/raw_modes/Canon EOS M200_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS M50/raw_modes/Canon EOS M50_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M50/raw_modes/Canon EOS M50_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS M50/raw_modes/Canon EOS M50_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M50/raw_modes/Canon EOS M50_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS M50m2/raw_modes/Canon EOS M50m2_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M50m2/raw_modes/Canon EOS M50m2_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS M50m2/raw_modes/Canon EOS M50m2_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M50m2/raw_modes/Canon EOS M50m2_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS M6 Mark II/raw_modes/Canon EOS M6 Mark II_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M6 Mark II/raw_modes/Canon EOS M6 Mark II_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4640
       activeArea:
         p:
-          x: 156
-          y: 84
+          x: 144
+          y: 72
         d:
-          w: 6960
-          h: 4640
+          w: 6982
+          h: 4658
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS M6 Mark II/raw_modes/Canon EOS M6 Mark II_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS M6 Mark II/raw_modes/Canon EOS M6 Mark II_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4640
       activeArea:
         p:
-          x: 156
-          y: 84
+          x: 144
+          y: 72
         d:
-          w: 6960
-          h: 4640
+          w: 6982
+          h: 4658
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_crop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_crop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2784
       activeArea:
         p:
-          x: 164
-          y: 58
+          x: 152
+          y: 46
         d:
-          w: 4176
-          h: 2784
+          w: 4198
+          h: 2802
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2784
       activeArea:
         p:
-          x: 164
-          y: 58
+          x: 152
+          y: 46
         d:
-          w: 4176
-          h: 2784
+          w: 4198
+          h: 2802
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_nocrop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_nocrop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4480
       activeArea:
         p:
-          x: 156
-          y: 58
+          x: 144
+          y: 46
         d:
-          w: 6720
-          h: 4480
+          w: 6742
+          h: 4498
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4480
       activeArea:
         p:
-          x: 156
-          y: 58
+          x: 144
+          y: 46
         d:
-          w: 6720
-          h: 4480
+          w: 6742
+          h: 4498
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_crop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_crop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2784
       activeArea:
         p:
-          x: 164
-          y: 58
+          x: 152
+          y: 46
         d:
-          w: 4176
-          h: 2784
+          w: 4198
+          h: 2802
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2784
       activeArea:
         p:
-          x: 164
-          y: 58
+          x: 152
+          y: 46
         d:
-          w: 4176
-          h: 2784
+          w: 4198
+          h: 2802
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_nocrop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_nocrop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4480
       activeArea:
         p:
-          x: 156
-          y: 58
+          x: 144
+          y: 46
         d:
-          w: 6720
-          h: 4480
+          w: 6742
+          h: 4498
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R/raw_modes/Canon EOS R_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4480
       activeArea:
         p:
-          x: 156
-          y: 58
+          x: 144
+          y: 46
         d:
-          w: 6720
-          h: 4480
+          w: 6742
+          h: 4498
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_crop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_crop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3392
       activeArea:
         p:
-          x: 144
-          y: 108
+          x: 128
+          y: 96
         d:
-          w: 5088
-          h: 3392
+          w: 5118
+          h: 3414
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3392
       activeArea:
         p:
-          x: 144
-          y: 108
+          x: 128
+          y: 96
         d:
-          w: 5088
-          h: 3392
+          w: 5118
+          h: 3414
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_nocrop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_nocrop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 5464
       activeArea:
         p:
-          x: 144
-          y: 112
+          x: 132
+          y: 100
         d:
-          w: 8192
-          h: 5464
+          w: 8214
+          h: 5478
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 5464
       activeArea:
         p:
-          x: 144
-          y: 112
+          x: 132
+          y: 100
         d:
-          w: 8192
-          h: 5464
+          w: 8214
+          h: 5478
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_crop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_crop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3392
       activeArea:
         p:
-          x: 144
-          y: 108
+          x: 128
+          y: 96
         d:
-          w: 5088
-          h: 3392
+          w: 5118
+          h: 3414
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3392
       activeArea:
         p:
-          x: 144
-          y: 108
+          x: 128
+          y: 96
         d:
-          w: 5088
-          h: 3392
+          w: 5118
+          h: 3414
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_nocrop_dual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_nocrop_dual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 5464
       activeArea:
         p:
-          x: 144
-          y: 112
+          x: 132
+          y: 100
         d:
-          w: 8192
-          h: 5464
+          w: 8214
+          h: 5478
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 5464
       activeArea:
         p:
-          x: 144
-          y: 112
+          x: 132
+          y: 100
         d:
-          w: 8192
-          h: 5464
+          w: 8214
+          h: 5478
       blacklevels:
         levels:
           - 510/1

--- a/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2272
       activeArea:
         p:
-          x: 156
-          y: 108
+          x: 144
+          y: 96
         d:
-          w: 3408
-          h: 2272
+          w: 3430
+          h: 2286
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 84
-          y: 50
+          x: 72
+          y: 38
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3662
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2272
       activeArea:
         p:
-          x: 156
-          y: 108
+          x: 144
+          y: 96
         d:
-          w: 3408
-          h: 2272
+          w: 3430
+          h: 2286
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS R6/raw_modes/Canon EOS R6_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 84
-          y: 50
+          x: 72
+          y: 38
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3662
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_CRAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2592
       activeArea:
         p:
-          x: 124
-          y: 56
+          x: 112
+          y: 44
         d:
-          w: 3888
-          h: 2592
+          w: 3918
+          h: 2610
       blacklevels:
         levels:
           - 513/1

--- a/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4160
       activeArea:
         p:
-          x: 132
-          y: 56
+          x: 120
+          y: 44
         d:
-          w: 6240
-          h: 4160
+          w: 6262
+          h: 4178
       blacklevels:
         levels:
           - 513/1

--- a/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_RAW_ISO_100_crop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 2592
       activeArea:
         p:
-          x: 124
-          y: 56
+          x: 112
+          y: 44
         d:
-          w: 3888
-          h: 2592
+          w: 3918
+          h: 2610
       blacklevels:
         levels:
           - 513/1

--- a/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS RP/raw_modes/Canon EOS RP_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4160
       activeArea:
         p:
-          x: 132
-          y: 56
+          x: 120
+          y: 44
         d:
-          w: 6240
-          h: 4160
+          w: 6262
+          h: 4178
       blacklevels:
         levels:
           - 513/1

--- a/rawler/data/testdata/cameras/Canon/EOS Rebel SL3/raw_modes/EOS Rebel SL3.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS Rebel SL3/raw_modes/EOS Rebel SL3.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 4000
       activeArea:
         p:
-          x: 276
-          y: 48
+          x: 264
+          y: 36
         d:
-          w: 6000
-          h: 4000
+          w: 6022
+          h: 4018
       blacklevels:
         levels:
           - 511/1

--- a/rawler/data/testdata/cameras/Canon/EOS-1D X Mark III/raw_modes/Canon EOS-1D X Mark III_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS-1D X Mark III/raw_modes/Canon EOS-1D X Mark III_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 84
-          y: 50
+          x: 72
+          y: 38
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3662
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/EOS-1D X Mark III/raw_modes/Canon EOS-1D X Mark III_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/EOS-1D X Mark III/raw_modes/Canon EOS-1D X Mark III_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 84
-          y: 50
+          x: 72
+          y: 38
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3662
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot G5 X Mark II/raw_modes/Canon PowerShot G5 X Mark II_CRAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot G5 X Mark II/raw_modes/Canon PowerShot G5 X Mark II_CRAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3666
       blacklevels:
         levels:
           - 2048/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot G5 X Mark II/raw_modes/Canon PowerShot G5 X Mark II_RAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot G5 X Mark II/raw_modes/Canon PowerShot G5 X Mark II_RAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3666
       blacklevels:
         levels:
           - 2048/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot G7 X Mark III/raw_modes/Canon PowerShot G7 X Mark III_CRAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot G7 X Mark III/raw_modes/Canon PowerShot G7 X Mark III_CRAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3666
       blacklevels:
         levels:
           - 2048/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot G7 X Mark III/raw_modes/Canon PowerShot G7 X Mark III_RAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot G7 X Mark III/raw_modes/Canon PowerShot G7 X Mark III_RAW_ISO_200_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3648
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5472
-          h: 3648
+          w: 5494
+          h: 3666
       blacklevels:
         levels:
           - 2048/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3888
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5184
-          h: 3888
+          w: 5206
+          h: 3906
       blacklevels:
         levels:
           - 512/1

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -18,11 +18,11 @@ data:
           h: 3888
       activeArea:
         p:
-          x: 132
-          y: 40
+          x: 120
+          y: 28
         d:
-          w: 5184
-          h: 3888
+          w: 5206
+          h: 3906
       blacklevels:
         levels:
           - 512/1


### PR DESCRIPTION
Metadata is sometimes not correct, especially on crop mode.
The offsets for bottom/right are sometimes few pixels overflowing
the width/height.

We use the area anyway, just limits the offsets to image bounds.