### PR TITLE
CRW: Pass 4-component WB

### DIFF
--- a/rawler/data/testdata/cameras/Canon/PowerShot G1/raw_modes/Canon PowerShot G1_ISO_50.CRW.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot G1/raw_modes/Canon PowerShot G1_ISO_50.CRW.analyze.yaml
@@ -26,10 +26,10 @@ data:
       whitelevels:
         - 1023
       wbCoeffs:
-        - 1.0491401
-        - 0.84766585
-        - 0.7223587
-        - ~
+        - 1.5088339
+        - 1.4381626
+        - 1.0
+        - 1.0388693
     rawMetadata:
       exif:
         orientation: ~


### PR DESCRIPTION
Canon G1 uses 4 colors in Bayer matrix