### PR TITLE
Fix common typo in lens files: `s/\[(\d), 10\]/[$1, 1]/g`

### DIFF
--- a/rawler/data/lenses/e_mount/sony.toml
+++ b/rawler/data/lenses/e_mount/sony.toml
@@ -158,7 +158,7 @@ lens_id = 32803
 make = "Sony"
 model = "E 18-50mm F4-5.6"
 focal_range = [[18, 1], [50, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "e-mount"
@@ -463,7 +463,7 @@ lens_id = 32864
 make = "Sony"
 model = "FE 28-60mm F4-5.6"
 focal_range = [[28, 1], [60, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "e-mount"

--- a/rawler/data/lenses/e_mount/tamron.toml
+++ b/rawler/data/lenses/e_mount/tamron.toml
@@ -76,7 +76,7 @@ lens_id = 49466
 make = "Tamron"
 model = "150-500mm F5-6.7 Di III VC VXD"
 focal_range = [[150, 1], [500, 1]]
-aperture_range = [[5, 10], [67, 10]]
+aperture_range = [[5, 1], [67, 10]]
 
 [[lenses]]
 mount = "e-mount"

--- a/rawler/data/lenses/ef_mount/canon.toml
+++ b/rawler/data/lenses/ef_mount/canon.toml
@@ -1612,7 +1612,7 @@ lens_id = 4145
 make = "Canon"
 model = "EF-M 22mm f/2 STM"
 focal_range = [[22, 1], [22, 1]]
-aperture_range = [[2, 1], [2, 10]]
+aperture_range = [[2, 1], [2, 1]]
 
 [[lenses]]
 mount = "ef-mount"

--- a/rawler/data/lenses/ef_mount/sigma.toml
+++ b/rawler/data/lenses/ef_mount/sigma.toml
@@ -52,7 +52,7 @@ lens_id = 8
 make = "Sigma"
 model = "70-300mm f/4-5.6 [APO] DG Macro"
 focal_range = [[70, 1], [300, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -60,7 +60,7 @@ lens_id = 9
 make = "Sigma"
 model = "55-200mm f/4-5.6 DC"
 focal_range = [[55, 1], [200, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -204,7 +204,7 @@ lens_id = 137
 make = "Sigma"
 model = "50-200mm f/4-5.6 DC OS HSM"
 focal_range = [[50, 1], [200, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -292,7 +292,7 @@ lens_id = 137
 make = "Sigma"
 model = "70-300mm f/4-5.6 DG OS"
 focal_range = [[70, 1], [300, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -365,7 +365,7 @@ lens_id = 152
 make = "Sigma"
 model = "10-20mm f/4-5.6"
 focal_range = [[10, 1], [20, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -389,7 +389,7 @@ lens_id = 153
 make = "Sigma"
 model = "50-500mm f/4-6.3 APO HSM EX"
 focal_range = [[50, 1], [500, 1]]
-aperture_range = [[4, 10], [63, 10]]
+aperture_range = [[4, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -525,7 +525,7 @@ lens_id = 172
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | S"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -589,7 +589,7 @@ lens_id = 174
 make = "Sigma"
 model = "150-500mm f/5-6.3 APO DG OS HSM"
 focal_range = [[150, 1], [500, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -686,7 +686,7 @@ lens_id = 181
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | S + 1.4x"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -694,7 +694,7 @@ lens_id = 182
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | S + 2x"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -727,7 +727,7 @@ lens_id = 183
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | C"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -735,7 +735,7 @@ lens_id = 183
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | S"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -743,7 +743,7 @@ lens_id = 183
 make = "Sigma"
 model = "100-400mm f/5-6.3 DG OS HSM"
 focal_range = [[100, 1], [400, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -913,7 +913,7 @@ lens_id = 368
 make = "Sigma"
 model = "150-600mm f/5-6.3 DG OS HSM | S"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -985,7 +985,7 @@ lens_id = 624
 make = "Sigma"
 model = "150-600mm f/5-6.3 | C"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"

--- a/rawler/data/lenses/ef_mount/tamron.toml
+++ b/rawler/data/lenses/ef_mount/tamron.toml
@@ -164,7 +164,7 @@ lens_id = 156
 make = "Tamron"
 model = "SP 70-300mm f/4-5.6 Di VC USD (A005)"
 focal_range = [[70, 1], [300, 1]]
-aperture_range = [[4, 10], [56, 10]]
+aperture_range = [[4, 1], [56, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -368,7 +368,7 @@ lens_id = 747
 make = "Tamron"
 model = "SP 150-600mm f/5-6.3 Di VC USD G2"
 focal_range = [[150, 1], [600, 1]]
-aperture_range = [[5, 10], [63, 10]]
+aperture_range = [[5, 1], [63, 10]]
 
 [[lenses]]
 mount = "ef-mount"
@@ -384,7 +384,7 @@ lens_id = 748
 make = "Tamron"
 model = "70-210mm f/4 Di VC USD (A034) + 2x"
 focal_range = [[70, 1], [210, 1]]
-aperture_range = [[4, 1], [4, 10]]
+aperture_range = [[4, 1], [4, 1]]
 
 [[lenses]]
 mount = "ef-mount"

--- a/rawler/data/lenses/rf_mount/canon.toml
+++ b/rawler/data/lenses/rf_mount/canon.toml
@@ -86,7 +86,7 @@ lens_subid = 265
 make = "Canon"
 model = "RF 24-240mm F4-6.3 IS USM"
 focal_range = [[24, 1], [240, 1]]
-aperture_range = [[4, 10], [63, 10]]
+aperture_range = [[4, 1], [63, 10]]
 
 [[lenses]]
 mount = "rf-mount"
@@ -105,7 +105,7 @@ lens_subid = 267
 make = "Canon"
 model = "RF 85mm F2 MACRO IS STM"
 focal_range = [[85, 1], [85, 1]]
-aperture_range = [[2, 1], [2, 10]]
+aperture_range = [[2, 1], [2, 1]]
 
 [[lenses]]
 mount = "rf-mount"
@@ -171,7 +171,7 @@ lens_subid = 274
 make = "Canon"
 model = "RF 24-105mm F4-7.1 IS STM"
 focal_range = [[24, 1], [105, 1]]
-aperture_range = [[4, 10], [71, 10]]
+aperture_range = [[4, 1], [71, 10]]
 
 [[lenses]]
 mount = "rf-mount"
@@ -240,7 +240,7 @@ lens_subid = 283
 make = "Canon"
 model = "RF 100-400mm F5.6-8 IS USM"
 focal_range = [[100, 1], [400, 1]]
-aperture_range = [[56, 10], [8, 10]]
+aperture_range = [[56, 10], [8, 1]]
 
 [[lenses]]
 mount = "rf-mount"


### PR DESCRIPTION
This corrects some lens entries from having the wrong aperture. I manually verified all the changes against the lens names.