### PR TITLE
Improve makedng command

### DIFF
--- a/bin/dnglab/src/analyze.rs
+++ b/bin/dnglab/src/analyze.rs
@@ -15,7 +15,7 @@ use std::{
   path::PathBuf,
 };
 
-fn print_output<T: Serialize + ?Sized>(obj: &T, options: &ArgMatches) -> anyhow::Result<()> {
+fn print_output<T: Serialize + ?Sized>(obj: &T, options: &ArgMatches) -> crate::Result<()> {
   if options.get_flag("yaml") {
     let yaml = serde_yaml::to_string(obj)?;
     println!("{}", yaml);
@@ -27,7 +27,7 @@ fn print_output<T: Serialize + ?Sized>(obj: &T, options: &ArgMatches) -> anyhow:
 }
 
 /// Analyze a given image
-pub async fn analyze(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn analyze(options: &ArgMatches) -> crate::Result<()> {
   let in_file: &PathBuf = options.get_one("FILE").expect("FILE not available");
 
   debug!("Infile: {:?}", in_file);

--- a/bin/dnglab/src/app.rs
+++ b/bin/dnglab/src/app.rs
@@ -3,12 +3,17 @@
 
 use std::path::PathBuf;
 
-use clap::{arg, builder::ValueParser, command, value_parser, ArgAction, Command};
+use clap::{
+  arg,
+  builder::{NonEmptyStringValueParser, ValueParser},
+  command, value_parser, ArgAction, Command,
+};
 use log::debug;
 use rawler::dng::{CropMode, DngCompression};
 
 use crate::makedng::{
-  CalibrationIlluminantArgParser, ColorMatrixArgParser, DngVersion, InputSourceUsageMap, LinearizationTableArgParser, WhiteBalanceInput, WhitePointArgParser,
+  CalibrationIlluminantArgParser, ColorMatrixArgParser, DngColorimetricReference, DngVersion, InputSourceUsageMap, LinearizationTableArgParser,
+  WhiteBalanceInput, WhitePointArgParser,
 };
 
 pub fn create_app() -> Command {
@@ -50,7 +55,11 @@ pub fn create_app() -> Command {
         .default_value("true")
         .default_missing_value("true"),
     )
-    .arg(arg!(--"artist" <artist> "Set the artist tag").required(false))
+    .arg(
+      arg!(--"artist" <artist> "Set the artist tag")
+        .required(false)
+        .value_parser(NonEmptyStringValueParser::new()),
+    )
     .arg(
       arg!(index: --"image-index" <index> "Select a specific image index (or 'all') if file is a image container")
         .required(false)
@@ -141,7 +150,7 @@ pub fn create_app() -> Command {
             .num_args(1..),
         )
         .arg(
-          arg!(map: --map <MAP> "Input usage map")
+          arg!(map: --map <map> "Input usage map")
             .required(false)
             .num_args(1..)
             .default_values(["0:raw", "0:preview", "0:thumbnail", "0:exif", "0:xmp"])
@@ -156,10 +165,36 @@ pub fn create_app() -> Command {
         )
          */
         .arg(
-          arg!(dng_backward_version: --"dng-backward-version" <VERSION> "DNG specification version")
+          arg!(dng_backward_version: --"dng-backward-version" <version> "DNG specification version")
             .required(false)
             .default_value("1.4")
             .value_parser(value_parser!(DngVersion)),
+        )
+        .arg(
+          arg!(colorimetric_reference: --"colorimetric-reference" <reference> "Reference for XYZ values")
+            .required(false)
+            .default_value("scene")
+            .value_parser(value_parser!(DngColorimetricReference)),
+        )
+        .arg(
+          arg!(unique_camera_model: --"unique-camera-model" <id> "Unique camera model")
+            .required(false)
+            .value_parser(NonEmptyStringValueParser::new()),
+        )
+        .arg(
+          arg!(artist: --"artist" <artist> "Set the Artist tag")
+            .required(false)
+            .value_parser(NonEmptyStringValueParser::new()),
+        )
+        .arg(
+          arg!(make: --"make" <make> "Set the Make tag")
+            .required(false)
+            .value_parser(NonEmptyStringValueParser::new()),
+        )
+        .arg(
+          arg!(model: --"model" <model> "Set the Model tag")
+            .required(false)
+            .value_parser(NonEmptyStringValueParser::new()),
         )
         .arg(
           arg!(matrix1: --matrix1 <MATRIX> "Matrix 1")

--- a/bin/dnglab/src/app.rs
+++ b/bin/dnglab/src/app.rs
@@ -146,6 +146,10 @@ pub fn create_app() -> Command {
         .arg(
           arg!(inputs: -i --"input" <INPUT> "Input files (raw, preview, exif, ...), index for map starts with 0")
             .required(true)
+            .long_help(
+              "Input files to merge into a single DNG file. Usually only a single input file is used.
+If multiple input files are given, --map should be used to specifiy how to interpret each intput file.",
+            )
             .value_parser(clap::value_parser!(PathBuf))
             .num_args(1..),
         )
@@ -154,6 +158,11 @@ pub fn create_app() -> Command {
             .required(false)
             .num_args(1..)
             .default_values(["0:raw", "0:preview", "0:thumbnail", "0:exif", "0:xmp"])
+            .long_help(
+              "When multiple input files given, each input file should be mapped to a specific type of data.
+First input file starts with index 0. Possible types are 'raw', 'preview', 'thumbnail', 'exif', 'xmp'.
+Input files which are not mapped are ignored.",
+            )
             .value_parser(value_parser!(InputSourceUsageMap)),
         )
         /*

--- a/bin/dnglab/src/cameras.rs
+++ b/bin/dnglab/src/cameras.rs
@@ -14,7 +14,7 @@ struct CameraRemarks {
 }
 
 /// Print list of supported cameras
-pub async fn cameras(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn cameras(options: &ArgMatches) -> crate::Result<()> {
   let cameras = global_loader().get_cameras();
 
   let mut map = BTreeMap::<String, BTreeMap<String, CameraRemarks>>::new();

--- a/bin/dnglab/src/convert.rs
+++ b/bin/dnglab/src/convert.rs
@@ -16,7 +16,7 @@ use crate::{AppError, Result, PKG_NAME, PKG_VERSION};
 use rawler::dng::convert::ConvertParams;
 
 /// Entry point for Clap sub command `convert`
-pub async fn convert(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn convert(options: &ArgMatches) -> crate::Result<()> {
   let now = Instant::now();
 
   let recursive = options.get_flag("recursive");

--- a/bin/dnglab/src/extract.rs
+++ b/bin/dnglab/src/extract.rs
@@ -20,7 +20,7 @@ use crate::{AppError, Result};
 const SUPPORTED_FILE_EXT: [&str; 1] = ["DNG"];
 
 /// Entry point for Clap sub command `extract`
-pub async fn extract(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn extract(options: &ArgMatches) -> crate::Result<()> {
   let now = Instant::now();
 
   let proc = {

--- a/bin/dnglab/src/filemap.rs
+++ b/bin/dnglab/src/filemap.rs
@@ -81,14 +81,14 @@ impl MapMode {
   /// Construct new ProcessMode from given input and output
   pub fn new(input: &Path, output: &Path) -> Result<MapMode> {
     if !input.exists() {
-      return Err(AppError::NotExists(input.display().to_string()));
+      return Err(AppError::NotFound(input.to_owned()));
     }
     let input_md = input.metadata()?;
     if input_md.is_file() {
       Ok(MapMode::File(FileMap::new(&input.canonicalize()?, output)))
     } else if input_md.is_dir() {
       if !output.exists() {
-        return Err(AppError::NotExists(output.display().to_string()));
+        return Err(AppError::NotFound(output.to_owned()));
       }
       let output_md = output.metadata()?;
       if !output_md.is_dir() {

--- a/bin/dnglab/src/ftpconv.rs
+++ b/bin/dnglab/src/ftpconv.rs
@@ -39,7 +39,7 @@ impl FtpCallback for FtpState {
 }
 
 /// Entry point for Clap sub command `ftpconvert`
-pub async fn ftpserver(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn ftpserver(options: &ArgMatches) -> crate::Result<()> {
   let mut config = Config::new("foo").unwrap(); // TODO: Needs cleanup
 
   let params = ConvertParams {

--- a/bin/dnglab/src/gui.rs
+++ b/bin/dnglab/src/gui.rs
@@ -4,7 +4,7 @@
 use clap::ArgMatches;
 //use log::debug;
 
-pub async fn gui(_options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn gui(_options: &ArgMatches) -> crate::Result<()> {
   println!("GUI is not available yet");
   Ok(())
 }

--- a/bin/dnglab/src/jobs/extractraw.rs
+++ b/bin/dnglab/src/jobs/extractraw.rs
@@ -53,7 +53,7 @@ impl Display for JobResult {
 impl ExtractRawJob {
   fn internal_exec(&self) -> Result<JobResult> {
     if self.output.exists() && !self.replace {
-      return Err(AppError::DestExists(self.output.display().to_string()));
+      return Err(AppError::AlreadyExists(self.output.clone()));
     }
     let dng_file = File::open(&self.input)?;
 

--- a/bin/dnglab/src/lenses.rs
+++ b/bin/dnglab/src/lenses.rs
@@ -7,7 +7,7 @@ use clap::ArgMatches;
 use rawler::lens::get_lenses;
 
 /// Print list of supported lenses
-pub async fn lenses(options: &ArgMatches) -> anyhow::Result<()> {
+pub async fn lenses(options: &ArgMatches) -> crate::Result<()> {
   let lenses = get_lenses();
 
   let mut map = BTreeMap::<(String, String), Vec<String>>::new();

--- a/bin/dnglab/src/makedng.rs
+++ b/bin/dnglab/src/makedng.rs
@@ -14,6 +14,7 @@ use rawler::formats::jfif::{is_exif, is_jfif, Jfif};
 use rawler::formats::tiff::{self, Rational, SRational};
 use rawler::imgop::gamma::{apply_gamma, invert_gamma};
 
+use rawler::imgop::srgb::{srgb_apply_gamma, srgb_invert_gamma};
 use rawler::imgop::xyz::{self, Illuminant};
 use rawler::imgop::{scale_double_to_u16, scale_u16_to_double, scale_u8_to_double};
 use rawler::tags::{DngTag, TiffCommonTag};
@@ -334,66 +335,104 @@ impl clap::builder::TypedValueParser for LinearizationTableArgParser {
     let val = inner.parse_ref(cmd, arg, value)?;
 
     Ok(match val.as_str() {
-      "sRGB_8bit_gamma2.0" => (0..=u8::MAX)
+      "8bit_sRGB" => (0..=u8::MAX).map(scale_u8_to_double).map(srgb_apply_gamma).map(scale_double_to_u16).collect(),
+      "8bit_sRGB_invert" => (0..=u8::MAX).map(scale_u8_to_double).map(srgb_invert_gamma).map(scale_double_to_u16).collect(),
+
+      "16bit_sRGB" => (0..=u16::MAX).map(scale_u16_to_double).map(srgb_apply_gamma).map(scale_double_to_u16).collect(),
+      "16bit_sRGB_invert" => (0..=u16::MAX)
+        .map(scale_u16_to_double)
+        .map(srgb_invert_gamma)
+        .map(scale_double_to_u16)
+        .collect(),
+
+      "8bit_gamma1.8" => (0..=u8::MAX)
+        .map(scale_u8_to_double)
+        .map(|v| apply_gamma(v, 1.8))
+        .map(scale_double_to_u16)
+        .collect(),
+      "8bit_gamma1.8_invert" => (0..=u8::MAX)
+        .map(scale_u8_to_double)
+        .map(|v| invert_gamma(v, 1.8))
+        .map(scale_double_to_u16)
+        .collect(),
+
+      "8bit_gamma2.0" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| apply_gamma(v, 2.0))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_8bit_gamma2.0_invert" => (0..=u8::MAX)
+      "8bit_gamma2.0_invert" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| invert_gamma(v, 2.0))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_8bit_gamma2.2" => (0..=u8::MAX)
+
+      "8bit_gamma2.2" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| apply_gamma(v, 2.2))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_8bit_gamma2.2_invert" => (0..=u8::MAX)
+      "8bit_gamma2.2_invert" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| invert_gamma(v, 2.2))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_8bit_gamma2.4" => (0..=u8::MAX)
+
+      "8bit_gamma2.4" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| apply_gamma(v, 2.4))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_8bit_gamma2.4_invert" => (0..=u8::MAX)
+      "8bit_gamma2.4_invert" => (0..=u8::MAX)
         .map(scale_u8_to_double)
         .map(|v| invert_gamma(v, 2.4))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.0" => (0..=u16::MAX)
+
+      "16bit_gamma1.8" => (0..=u16::MAX)
+        .map(scale_u16_to_double)
+        .map(|v| apply_gamma(v, 1.8))
+        .map(scale_double_to_u16)
+        .collect(),
+      "16bit_gamma1.8_invert" => (0..=u16::MAX)
+        .map(scale_u16_to_double)
+        .map(|v| invert_gamma(v, 1.8))
+        .map(scale_double_to_u16)
+        .collect(),
+
+      "16bit_gamma2.0" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| apply_gamma(v, 2.0))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.0_invert" => (0..=u16::MAX)
+      "16bit_gamma2.0_invert" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| invert_gamma(v, 2.0))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.2" => (0..=u16::MAX)
+
+      "16bit_gamma2.2" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| apply_gamma(v, 2.2))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.2_invert" => (0..=u16::MAX)
+      "16bit_gamma2.2_invert" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| invert_gamma(v, 2.2))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.4" => (0..=u16::MAX)
+
+      "16bit_gamma2.4" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| apply_gamma(v, 2.4))
         .map(scale_double_to_u16)
         .collect(),
-      "sRGB_16bit_gamma2.4_invert" => (0..=u16::MAX)
+      "16bit_gamma2.4_invert" => (0..=u16::MAX)
         .map(scale_u16_to_double)
         .map(|v| invert_gamma(v, 2.4))
         .map(scale_double_to_u16)
         .collect(),
+
       _ => match val.split(',').map(str::trim).map(str::parse::<u16>).collect::<std::result::Result<Vec<_>, _>>() {
         Ok(items) => items,
         Err(fail) => {
@@ -412,18 +451,26 @@ impl clap::builder::TypedValueParser for LinearizationTableArgParser {
   fn possible_values(&self) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
     Some(Box::new(
       [
-        "sRGB_8bit_gamma2.0",
-        "sRGB_8bit_gamma2.2",
-        "sRGB_8bit_gamma2.4",
-        "sRGB_8bit_gamma2.0_invert",
-        "sRGB_8bit_gamma2.2_invert",
-        "sRGB_8bit_gamma2.4_invert",
-        "sRGB_16bit_gamma2.0",
-        "sRGB_16bit_gamma2.2",
-        "sRGB_16bit_gamma2.4",
-        "sRGB_16bit_gamma2.0_invert",
-        "sRGB_16bit_gamma2.2_invert",
-        "sRGB_16bit_gamma2.4_invert",
+        "8bit_sRGB",
+        "8bit_sRGB_invert",
+        "16bit_sRGB",
+        "16bit_sRGB_invert",
+        "8bit_gamma1.8",
+        "8bit_gamma1.8_invert",
+        "8bit_gamma2.0",
+        "8bit_gamma2.0_invert",
+        "8bit_gamma2.2",
+        "8bit_gamma2.2_invert",
+        "8bit_gamma2.4",
+        "8bit_gamma2.4_invert",
+        "16bit_gamma1.8",
+        "16bit_gamma1.8_invert",
+        "16bit_gamma2.0",
+        "16bit_gamma2.0_invert",
+        "16bit_gamma2.2",
+        "16bit_gamma2.2_invert",
+        "16bit_gamma2.4",
+        "16bit_gamma2.4_invert",
         "custom table (comma seperated)",
       ]
       .into_iter()

--- a/rawler/src/decoders/arw.rs
+++ b/rawler/src/decoders/arw.rs
@@ -156,11 +156,11 @@ impl<'a> Decoder for ArwDecoder<'a> {
               });
               decode_12le(&src, width, height, dummy)
             }
-            _ => return Err(RawlerError::General(format!("ARW2: Don't know how to decode images with {} bps", bps))),
+            _ => return Err(RawlerError::DecoderFailed(format!("ARW2: Don't know how to decode images with {} bps", bps))),
           }
         }
       }
-      _ => return Err(RawlerError::General(format!("ARW: Don't know how to decode type {}", compression))),
+      _ => return Err(RawlerError::DecoderFailed(format!("ARW: Don't know how to decode type {}", compression))),
     };
 
     let crop = Rect::from_tiff(raw).or_else(|| self.camera.crop_area.map(|area| Rect::new_with_borders(Dim2::new(width, height), &area)));
@@ -280,7 +280,7 @@ impl<'a> ArwDecoder<'a> {
     // wonderfullness of the Tiff-based ARW format, let's shoot from the hip
     let data = self.tiff.find_ifds_with_tag(TiffCommonTag::SubIFDs);
     if data.is_empty() {
-      return Err(RawlerError::General("ARW: Couldn't find the data IFD!".to_string()));
+      return Err(RawlerError::DecoderFailed("ARW: Couldn't find the data IFD!".to_string()));
     }
     let raw = data[0];
     let width = 3880;
@@ -326,7 +326,7 @@ impl<'a> ArwDecoder<'a> {
   fn image_srf(&self, file: &mut RawFile, dummy: bool) -> Result<RawImage> {
     let data = self.tiff.find_ifds_with_tag(TiffCommonTag::ImageWidth);
     if data.is_empty() {
-      return Err(RawlerError::General("ARW: Couldn't find the data IFD!".to_string()));
+      return Err(RawlerError::DecoderFailed("ARW: Couldn't find the data IFD!".to_string()));
     }
     let raw = data[0];
 
@@ -615,7 +615,7 @@ impl<'a> ArwDecoder<'a> {
         levels.force_u32(3) as f32,
       ]))
     } else {
-      Err(RawlerError::General("ARW: Couldn't find GRGB or RGGB levels".to_string()))
+      Err(RawlerError::DecoderFailed("ARW: Couldn't find GRGB or RGGB levels".to_string()))
     }
   }
 

--- a/rawler/src/decoders/cr2/colordata.rs
+++ b/rawler/src/decoders/cr2/colordata.rs
@@ -127,6 +127,9 @@ pub(crate) fn parse_colordata(colordata: &Entry) -> Result<ColorData> {
       })
     }
 
-    _ => Err(RawlerError::General(format!("Invalid COLORDATA tag: type {}", colordata.value_type_name()))),
+    _ => Err(RawlerError::DecoderFailed(format!(
+      "Invalid COLORDATA tag: type {}",
+      colordata.value_type_name()
+    ))),
   }
 }

--- a/rawler/src/decoders/crw.rs
+++ b/rawler/src/decoders/crw.rs
@@ -65,7 +65,7 @@ impl<'a> CrwDecoder<'a> {
 
     let makemodel = fetch_ciff_tag!(ciff, CiffTag::MakeModel).get_strings();
     if makemodel.len() < 2 {
-      return Err(RawlerError::General("CRW: MakeModel tag needs to have 2 strings".to_string()));
+      return Err(RawlerError::DecoderFailed("CRW: MakeModel tag needs to have 2 strings".to_string()));
     }
     let camera = rawloader.check_supported_with_everything(&makemodel[0], &makemodel[1], "")?;
 
@@ -178,7 +178,7 @@ impl<'a> CrwDecoder<'a> {
     let lowbits = !self.camera.find_hint("nolowbits");
     let dectable = fetch_ciff_tag!(self.ciff, CiffTag::DecoderTable).get_usize(0);
     if dectable > 2 {
-      return Err(RawlerError::General(format!("CRW: Unknown decoder table {}", dectable)));
+      return Err(RawlerError::DecoderFailed(format!("CRW: Unknown decoder table {}", dectable)));
     }
     Ok(Self::do_decode(file, lowbits, dectable, width, height, dummy))
   }

--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -45,7 +45,7 @@ impl<'a> Decoder for DngDecoder<'a> {
     let image = match fetch_tiff_tag!(raw, TiffCommonTag::Compression).force_u32(0) {
       1 => self.decode_uncompressed(file, raw, width * cpp, height, dummy)?,
       7 => self.decode_compressed(file, raw, width * cpp, height, cpp, dummy)?,
-      c => return Err(RawlerError::General(format!("Don't know how to read DNGs with compression {}", c))),
+      c => return Err(RawlerError::DecoderFailed(format!("Don't know how to read DNGs with compression {}", c))),
     };
 
     let orientation = Orientation::from_tiff(self.tiff.root_ifd());
@@ -352,7 +352,7 @@ impl<'a> DngDecoder<'a> {
       )
       .map_err(RawlerError::DecoderFailed)
     } else {
-      Err(RawlerError::General("DNG: didn't find tiles or strips".to_string()))
+      Err(RawlerError::DecoderFailed("DNG: didn't find tiles or strips".to_string()))
     }
   }
 }

--- a/rawler/src/decoders/erf.rs
+++ b/rawler/src/decoders/erf.rs
@@ -86,7 +86,7 @@ impl<'a> ErfDecoder<'a> {
   fn get_wb(&self) -> Result<[f32; 4]> {
     let levels = fetch_tiff_tag!(self.makernote, TiffCommonTag::EpsonWB);
     if levels.count() != 256 {
-      Err(RawlerError::General("ERF: Levels count is off".to_string()))
+      Err(RawlerError::DecoderFailed("ERF: Levels count is off".to_string()))
     } else {
       let r = BEu16(levels.get_data(), 48) as f32;
       let b = BEu16(levels.get_data(), 50) as f32;

--- a/rawler/src/decoders/iiq.rs
+++ b/rawler/src/decoders/iiq.rs
@@ -239,7 +239,7 @@ impl<'a> Decoder for IiqDecoder<'a> {
     debug!("RAW IIQ Format: {:?}", fmt);
 
     if width == 0 || height == 0 {
-      return Err(RawlerError::General("IIQ: couldn't find width and height".to_string()));
+      return Err(RawlerError::DecoderFailed("IIQ: couldn't find width and height".to_string()));
     }
 
     let data = file
@@ -621,7 +621,7 @@ impl<'a> IiqDecoder<'a> {
         width.1.force_usize(0), //
         height.1.force_usize(0),
       )),
-      _ => Err(RawlerError::General("Unable to find width/height in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find width/height in IIQ makernotes".to_string())),
     }
   }
 
@@ -702,7 +702,7 @@ impl<'a> IiqDecoder<'a> {
         let code = mode.1.force_u32(0);
         Ok(IiqCompression::from(code as usize))
       }
-      _ => Err(RawlerError::General("Unable to find compression mode in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find compression mode in IIQ makernotes".to_string())),
     }
   }
 
@@ -712,7 +712,7 @@ impl<'a> IiqDecoder<'a> {
         (mode.1.force_u64(0) + 8), //
         mode.0,
       )),
-      _ => Err(RawlerError::General("Unable to find data offset in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find data offset in IIQ makernotes".to_string())),
     }
   }
 
@@ -722,21 +722,21 @@ impl<'a> IiqDecoder<'a> {
         (mode.1.force_u64(0) + 8), //
         mode.0,
       )),
-      _ => Err(RawlerError::General("Unable to find strip offset in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find strip offset in IIQ makernotes".to_string())),
     }
   }
 
   fn wb_offset(&self) -> Result<u64> {
     match self.makernotes.get(&IiqTag::WhiteBalance.into()) {
       Some(mode) => Ok((mode.1.force_u64(0) + 8) as u64),
-      _ => Err(RawlerError::General("Unable to find whitebalance offset in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find whitebalance offset in IIQ makernotes".to_string())),
     }
   }
 
   fn blacklevel(&self) -> Result<u16> {
     match self.makernotes.get(&IiqTag::BlackLevel.into()) {
       Some(mode) => Ok(mode.1.force_u16(0)),
-      _ => Err(RawlerError::General("Unable to find lacklevel in IIQ makernotes".to_string())),
+      _ => Err(RawlerError::DecoderFailed("Unable to find lacklevel in IIQ makernotes".to_string())),
     }
   }
 

--- a/rawler/src/decoders/mod.rs
+++ b/rawler/src/decoders/mod.rs
@@ -369,7 +369,7 @@ impl RawLoader {
         $file
           .inner()
           .seek(SeekFrom::Start(0))
-          .map_err(|e| RawlerError::General(format!("I/O error while trying decoders: {:?}", e)))?
+          .map_err(|e| RawlerError::with_io_error("get_decoder(): failed to seek", &rawfile.path, e))?;
       };
     }
 
@@ -540,7 +540,7 @@ impl RawLoader {
 
     match panic::catch_unwind(AssertUnwindSafe(|| self.decode_unsafe(rawfile, params, dummy))) {
       Ok(val) => val,
-      Err(_) => Err(RawlerError::General(format!("Caught a panic while decoding.{}", BUG))),
+      Err(_) => Err(RawlerError::DecoderFailed(format!("Caught a panic while decoding.{}", BUG))),
     }
   }
 
@@ -572,7 +572,7 @@ impl RawLoader {
   pub fn decode_unwrapped(&self, rawfile: &mut RawFile) -> Result<RawImageData> {
     match panic::catch_unwind(AssertUnwindSafe(|| unwrapped::decode_unwrapped(rawfile))) {
       Ok(val) => val,
-      Err(_) => Err(RawlerError::General(format!("Caught a panic while decoding.{}", BUG))),
+      Err(_) => Err(RawlerError::DecoderFailed(format!("Caught a panic while decoding.{}", BUG))),
     }
   }
 }

--- a/rawler/src/decoders/nef.rs
+++ b/rawler/src/decoders/nef.rs
@@ -304,7 +304,7 @@ impl<'a> Decoder for NefDecoder<'a> {
     }
     let buf = root_ifd
       .singlestrip_data(file.inner())
-      .map_err(|e| RawlerError::General(format!("Failed to get strip data: {}", e)))?;
+      .map_err(|e| RawlerError::DecoderFailed(format!("Failed to get strip data: {}", e)))?;
     let compression = root_ifd.get_entry(TiffCommonTag::Compression).ok_or("Missing tag")?.force_usize(0);
     let width = fetch_tiff_tag!(root_ifd, TiffCommonTag::ImageWidth).force_usize(0);
     let height = fetch_tiff_tag!(root_ifd, TiffCommonTag::ImageLength).force_usize(0);
@@ -465,7 +465,7 @@ impl<'a> NefDecoder<'a> {
         x => Err(RawlerError::unsupported(&self.camera, format!("NEF: Don't know about WB version 0x{:x}", x))),
       }
     } else {
-      Err(RawlerError::General("NEF: Don't know how to fetch WB".to_string()))
+      Err(RawlerError::DecoderFailed("NEF: Don't know how to fetch WB".to_string()))
     }
   }
 

--- a/rawler/src/decoders/orf.rs
+++ b/rawler/src/decoders/orf.rs
@@ -107,7 +107,7 @@ pub fn parse_makernote<R: Read + Seek>(reader: &mut R, exif_ifd: &IFD) -> Result
         }
         Ok(Some(mainifd))
       }
-      _ => Err(RawlerError::General("EXIF makernote has unknown type".to_string())),
+      _ => Err(RawlerError::DecoderFailed("EXIF makernote has unknown type".to_string())),
     }
   } else {
     Ok(None)
@@ -393,7 +393,7 @@ impl<'a> OrfDecoder<'a> {
       _ => {
         let ifd = self.makernote.find_ifds_with_tag(OrfImageProcessing::OrfBlackLevels);
         if ifd.is_empty() {
-          return Err(RawlerError::General("ORF: Couldn't find ImgProc IFD".to_string()));
+          return Err(RawlerError::DecoderFailed("ORF: Couldn't find ImgProc IFD".to_string()));
         }
         let wbs = fetch_tiff_tag!(ifd[0], OrfImageProcessing::WB_RBLevels);
         Ok([wbs.force_f32(0), 256.0, 256.0, wbs.force_f32(1)])

--- a/rawler/src/decoders/raf.rs
+++ b/rawler/src/decoders/raf.rs
@@ -146,7 +146,7 @@ fn parse_raf(file: &mut RawFile) -> Result<IFD> {
   file
     .inner()
     .seek(SeekFrom::Start(0))
-    .map_err(|e| RawlerError::General(format!("I/O error while trying decoders: {:?}", e)))?;
+    .map_err(|e| RawlerError::with_io_error("RAF: failed to seek", &file.path, e))?;
 
   let stream = file.inner();
   stream.seek(SeekFrom::Start(RAF_TIFF1_PTR_OFFSET))?;
@@ -567,7 +567,7 @@ impl<'a> RafDecoder<'a> {
         Ok(out)
       }
     } else {
-      Err(RawlerError::General("no active_area for fuji_rotate".to_string()))
+      Err(RawlerError::DecoderFailed("no active_area for fuji_rotate".to_string()))
     }
   }
 }

--- a/rawler/src/decoders/rw2.rs
+++ b/rawler/src/decoders/rw2.rs
@@ -185,7 +185,7 @@ impl<'a> Decoder for Rw2Decoder<'a> {
     if let Some(data) = self.tiff.get_entry(PanasonicTag::JpegData) {
       let buf = data.get_data();
       let img = image::load_from_memory_with_format(buf, image::ImageFormat::Jpeg)
-        .map_err(|e| RawlerError::General(format!("Unable to load jpeg preview: {:?}", e)))?;
+        .map_err(|e| RawlerError::DecoderFailed(format!("Unable to load jpeg preview: {:?}", e)))?;
       return Ok(Some(img));
     }
     Ok(None)
@@ -220,7 +220,7 @@ impl<'a> Rw2Decoder<'a> {
       let b = fetch_tiff_tag!(self.tiff, PanasonicTag::PanaWBs2B).force_u32(0) as f32;
       Ok([r, g, g, b])
     } else {
-      Err(RawlerError::General("Couldn't find WB".to_string()))
+      Err(RawlerError::DecoderFailed("RW2: Couldn't find WB".to_string()))
     }
   }
 

--- a/rawler/src/decoders/srw.rs
+++ b/rawler/src/decoders/srw.rs
@@ -481,7 +481,7 @@ impl<'a> SrwDecoder<'a> {
     let rggb_blacks = fetch_tiff_tag!(self.makernote, SrwMakernote::SrwRGGBBlacks);
 
     if rggb_levels.count() != 4 || rggb_blacks.count() != 4 {
-      Err(RawlerError::General("SRW: RGGB Levels and Blacks don't have 4 elements".to_string()))
+      Err(RawlerError::DecoderFailed("SRW: RGGB Levels and Blacks don't have 4 elements".to_string()))
     } else {
       Ok([
         (rggb_levels.force_u32(0) as f32 - rggb_blacks.force_u32(0) as f32) / 4096.0,

--- a/rawler/src/decoders/tfr.rs
+++ b/rawler/src/decoders/tfr.rs
@@ -87,7 +87,7 @@ impl<'a> Decoder for TfrDecoder<'a> {
     let root_ifd = &self.tiff.root_ifd();
     let buf = root_ifd
       .singlestrip_data(file.inner())
-      .map_err(|e| RawlerError::General(format!("Failed to get strip data: {}", e)))?;
+      .map_err(|e| RawlerError::DecoderFailed(format!("Failed to get strip data: {}", e)))?;
     let compression = root_ifd.get_entry(TiffCommonTag::Compression).ok_or("Missing tag")?.force_usize(0);
     let width = fetch_tiff_tag!(root_ifd, TiffCommonTag::ImageWidth).force_usize(0);
     let height = fetch_tiff_tag!(root_ifd, TiffCommonTag::ImageLength).force_usize(0);

--- a/rawler/src/formats/jfif.rs
+++ b/rawler/src/formats/jfif.rs
@@ -175,12 +175,8 @@ impl<R: Read + Seek> ReadSegment<&mut R> for App1 {
       reader.read_exact(&mut xmp_str)?;
       if xmp_str == APP1_XMP_MARKER.as_bytes() {
         log::debug!("Found APP1 XMP marker");
-        //let zero_byte = reader.read_u8()?;
-        //assert_eq!(zero_byte, 0);
         let mut xpacket = vec![0; len as usize - xmp_str.len() - 2];
-
         reader.read_exact(&mut xpacket)?;
-        //dump_buf("/tmp/dump.1",&xpacket);
         reader.seek(SeekFrom::Start(pos + len))?;
         return Ok(Self {
           len,
@@ -190,12 +186,11 @@ impl<R: Read + Seek> ReadSegment<&mut R> for App1 {
         reader.seek(SeekFrom::Current(-(xmp_str.len() as i64)))?;
       }
     }
-    log::debug!("Found APP1: UNKNOWN");
     reader.seek(SeekFrom::Start(pos + len))?;
-    return Ok(Self {
+    Ok(Self {
       len,
       payload: Payload::Unknown,
-    });
+    })
   }
 }
 
@@ -301,7 +296,7 @@ pub fn is_jfif(file: &mut RawFile) -> bool {
         //panic!("Failed: {:x} {:x} {:x} {:x}", buf[0], buf[1], buf[2], buf[3]);
       }
       result
-    },
+    }
     Err(err) => {
       log::error!("is_jfif(): {:?}", err);
       false

--- a/rawler/src/formats/mod.rs
+++ b/rawler/src/formats/mod.rs
@@ -3,5 +3,5 @@
 
 pub mod bmff;
 pub mod ciff;
-pub mod tiff;
 pub mod jfif;
+pub mod tiff;

--- a/rawler/src/imgop/gamma.rs
+++ b/rawler/src/imgop/gamma.rs
@@ -1,37 +1,10 @@
 // SPDX-License-Identifier: LGPL-2.1
 // Copyright 2021 Daniel Vogelbacher <daniel@chaospixel.com>
 
-use rayon::prelude::*;
-
-const BREAK_POINT: f32 = 0.00304;
-const SLOPE: f32 = 12.92;
-
-/// The gamma value for sRGB should be 2.4 but you can choose
-/// any other gamma here.
-/// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
 pub fn apply_gamma(v: f32, gamma: f32) -> f32 {
-  if v <= BREAK_POINT {
-    v * SLOPE
-  } else {
-    v.powf(1.0 / gamma) * 1.0555 - 0.0055
-  }
+  v.powf(1.0 / gamma)
 }
 
-/// Apply gamma correction to whole buffer
-pub fn apply_gamma_inplace(pixels: &mut Vec<f32>, gamma: f32) {
-  pixels.par_iter_mut().for_each(|p| *p = apply_gamma(*p, gamma));
-}
-
-/// Invert sRGB gamma correction
 pub fn invert_gamma(v: f32, gamma: f32) -> f32 {
-  if v <= BREAK_POINT * SLOPE {
-    v / SLOPE
-  } else {
-    ((v + 0.0055) / 1.0055).powf(gamma)
-  }
-}
-
-/// Invert gamma correction to whole buffer
-pub fn invert_gamma_inplace(pixels: &mut Vec<f32>, gamma: f32) {
-  pixels.par_iter_mut().for_each(|p| *p = invert_gamma(*p, gamma));
+  v.powf(gamma)
 }

--- a/rawler/src/imgop/srgb.rs
+++ b/rawler/src/imgop/srgb.rs
@@ -1,9 +1,56 @@
 // SPDX-License-Identifier: LGPL-2.1
 // Copyright 2021 Daniel Vogelbacher <daniel@chaospixel.com>
 
-use super::gamma::apply_gamma_inplace;
+use rayon::prelude::*;
 
-/// Apply sRGB specific gamma correction
-pub fn srgb_gamma_transform(pixels: &mut Vec<f32>) {
-  apply_gamma_inplace(pixels, 2.4)
+// Reference for sRGB:
+//
+// https://onlinelibrary.wiley.com/doi/pdf/10.1002/9781119021780.app8
+//
+// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+// http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_RGB.html
+// /// http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
+//
+
+/// sRGB gamma
+const SRGB_GAMMA: f32 = 2.4;
+
+/// sRGB crossover point between linear and exponential part
+const SRGB_CROSSOVER_POINT: f32 = 0.00304;
+
+/// sRGB gain for linear part, specified for gamma 2.4
+const LINEAR_GAIN: f32 = 12.92;
+
+/// sRGB gain for exponential part
+const SRGB_GAIN: f32 = 1.055;
+
+/// sRGB offset for exponential part
+const SRGB_OFFSET: f32 = SRGB_GAIN - 1.0; // 0.055
+
+/// Apply sRGB gamma
+pub fn srgb_apply_gamma(v: f32) -> f32 {
+  if v <= SRGB_CROSSOVER_POINT {
+    v * LINEAR_GAIN
+  } else {
+    v.powf(1.0 / SRGB_GAMMA) * SRGB_GAIN - SRGB_OFFSET
+  }
+}
+
+/// Invert sRGB gamma correction
+pub fn srgb_invert_gamma(v: f32) -> f32 {
+  if v <= SRGB_CROSSOVER_POINT * LINEAR_GAIN {
+    v / LINEAR_GAIN
+  } else {
+    ((v + SRGB_OFFSET) / SRGB_GAIN).powf(SRGB_GAMMA)
+  }
+}
+
+/// Apply gamma correction to whole buffer
+pub fn srgb_apply_gamma_inplace(pixels: &mut [f32]) {
+  pixels.par_iter_mut().for_each(|p| *p = srgb_apply_gamma(*p));
+}
+
+/// Invert gamma correction to whole buffer
+pub fn srgb_invert_gamma_inplace(pixels: &mut [f32]) {
+  pixels.par_iter_mut().for_each(|p| *p = srgb_invert_gamma(*p));
 }

--- a/rawler/src/lib.rs
+++ b/rawler/src/lib.rs
@@ -273,17 +273,17 @@ impl From<Cursor<Vec<u8>>> for RawFile {
 
 #[derive(Error, Debug)]
 pub enum RawlerError {
-  #[error("File is unsupported: {}, model \"{}\", make: \"{}\", mode: \"{}\"", what, model, make, mode)]
+  #[error(
+    "File is unsupported: {}, model '{}', make: '{}', mode: '{}'\nPlease report this issue at 'https://github.com/dnglab/dnglab/issues'!",
+    what,
+    model,
+    make,
+    mode
+  )]
   Unsupported { what: String, model: String, make: String, mode: String },
 
-  #[error("{}", _0)]
-  General(String),
-
-  #[error("{}", _0)]
+  #[error("Decoder failed: {}", _0)]
   DecoderFailed(String),
-
-  #[error("{}", _0)]
-  IOErr(String),
 }
 
 pub type Result<T> = std::result::Result<T, RawlerError>;
@@ -299,7 +299,7 @@ impl RawlerError {
   }
 
   pub fn with_io_error(context: impl AsRef<str>, path: impl AsRef<Path>, error: std::io::Error) -> Self {
-    Self::General(format!(
+    Self::DecoderFailed(format!(
       "I/O error in context '{}', {} on file: {}",
       context.as_ref(),
       error,
@@ -312,43 +312,43 @@ impl From<std::io::Error> for RawlerError {
   fn from(err: std::io::Error) -> Self {
     log::error!("I/O error: {}", err.to_string());
     log::error!("Backtrace:\n{:?}", backtrace::Backtrace::new());
-    Self::IOErr(format!("I/O Error: {}", err))
+    Self::DecoderFailed(format!("I/O Error without context: {}", err))
   }
 }
 
 impl From<&String> for RawlerError {
   fn from(str: &String) -> Self {
-    Self::General(str.clone())
+    Self::DecoderFailed(str.clone())
   }
 }
 
 impl From<&str> for RawlerError {
   fn from(str: &str) -> Self {
-    Self::General(str.to_string())
+    Self::DecoderFailed(str.to_string())
   }
 }
 
 impl From<std::fmt::Arguments<'_>> for RawlerError {
   fn from(fmt: std::fmt::Arguments) -> Self {
-    Self::General(fmt.to_string())
+    Self::DecoderFailed(fmt.to_string())
   }
 }
 
 impl From<String> for RawlerError {
   fn from(str: String) -> Self {
-    Self::General(str)
+    Self::DecoderFailed(str)
   }
 }
 
 impl From<TiffError> for RawlerError {
   fn from(err: TiffError) -> Self {
-    Self::General(err.to_string())
+    Self::DecoderFailed(err.to_string())
   }
 }
 
 impl From<JfifError> for RawlerError {
   fn from(err: JfifError) -> Self {
-    Self::General(err.to_string())
+    Self::DecoderFailed(err.to_string())
   }
 }
 

--- a/rawler/src/rawimage.rs
+++ b/rawler/src/rawimage.rs
@@ -332,7 +332,7 @@ impl RawImage {
       wb_coeff,
       active_area: self.active_area,
       crop_area: self.crop_area,
-      gamma: 2.4,
+      //gamma: 2.4,
     };
 
     Ok(params)

--- a/rawler/tests/mod.rs
+++ b/rawler/tests/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "samplecheck")]
 mod cameras;
 #[cfg(feature = "samplecheck")]
-mod issues;
-#[cfg(feature = "samplecheck")]
 mod common;
+#[cfg(feature = "samplecheck")]
+mod issues;


### PR DESCRIPTION
````
Lowlevel command to make a DNG file

Usage: dnglab makedng [OPTIONS] --input <INPUT>...

Options:
  -d...
          turns on debugging mode

  -o, --output <OUTPUT>
          Output DNG file path

  -i, --input <INPUT>...
          Input files to merge into a single DNG file. Usually only a single input file is used.
          If multiple input files are given, --map should be used to specifiy how to interpret each intput file.

  -v
          Print more messages

      --map <map>...
          When multiple input files given, each input file should be mapped to a specific type of data.
          First input file starts with index 0. Possible types are 'raw', 'preview', 'thumbnail', 'exif', 'xmp'.
          Input files which are not mapped are ignored.
          
          [default: 0:raw 0:preview 0:thumbnail 0:exif 0:xmp]

      --dng-backward-version <version>
          DNG specification version
          
          [default: 1.4]
          [possible values: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6]

      --colorimetric-reference <reference>
          Reference for XYZ values
          
          [default: scene]
          [possible values: scene, output]

      --unique-camera-model <id>
          Unique camera model

      --artist <artist>
          Set the Artist tag

      --make <make>
          Set the Make tag

      --model <model>
          Set the Model tag

      --matrix1 <MATRIX>
          Matrix 1
          
          [possible values: XYZ_sRGB_D50, XYZ_sRGB_D65, XYZ_AdobeRGB_D50, XYZ_AdobeRGB_D65, "custom 3x3 matrix (comma seperated)"]

      --matrix2 <MATRIX>
          Matrix 2
          
          [possible values: XYZ_sRGB_D50, XYZ_sRGB_D65, XYZ_AdobeRGB_D50, XYZ_AdobeRGB_D65, "custom 3x3 matrix (comma seperated)"]

      --matrix3 <MATRIX>
          Matrix 3
          
          [possible values: XYZ_sRGB_D50, XYZ_sRGB_D65, XYZ_AdobeRGB_D50, XYZ_AdobeRGB_D65, "custom 3x3 matrix (comma seperated)"]

      --illuminant1 <ILLUMINANT>
          Illuminant 1
          
          [possible values: Unknown, A, B, C, D50, D55, D65, D75]

      --illuminant2 <ILLUMINANT>
          Illuminant 2
          
          [possible values: Unknown, A, B, C, D50, D55, D65, D75]

      --illuminant3 <ILLUMINANT>
          Illuminant 3
          
          [possible values: Unknown, A, B, C, D50, D55, D65, D75]

      --linearization <TABLE>
          Linearization table
          
          [possible values: 8bit_sRGB, 8bit_sRGB_invert, 16bit_sRGB, 16bit_sRGB_invert, 8bit_gamma1.8, 8bit_gamma1.8_invert, 8bit_gamma2.0, 8bit_gamma2.0_invert, 8bit_gamma2.2, 8bit_gamma2.2_invert, 8bit_gamma2.4, 8bit_gamma2.4_invert, 16bit_gamma1.8, 16bit_gamma1.8_invert, 16bit_gamma2.0, 16bit_gamma2.0_invert, 16bit_gamma2.2, 16bit_gamma2.2_invert, 16bit_gamma2.4, 16bit_gamma2.4_invert, "custom table (comma seperated)"]

      --wb <R,G,B>
          Whitebalance as-shot

      --white-xy <x,y>
          Whitebalance as-shot encoded as xy chromaticity coordinates
          
          [possible values: D50, D65, "custom x,y value (comma seperated)"]

  -f, --override
          Override existing files

  -h, --help
          Print help (see a summary with '-h')

````