### PR TITLE
Make DNG OpcodeLists available from rawler

### DIFF
--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -95,7 +95,8 @@ impl<'a> Decoder for DngDecoder<'a> {
       cam.clean_make = known_cam.clean_make;
       cam.clean_model = known_cam.clean_model;
     }
-    let exif = Exif::new(self.tiff.root_ifd())?;
+    let mut exif = Exif::new(self.tiff.root_ifd())?;
+    exif.extend_from_raw_ifd(raw)?;
     let mdata = RawMetadata::new(&cam, exif);
     Ok(mdata)
   }

--- a/rawler/src/exif.rs
+++ b/rawler/src/exif.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
   formats::tiff::{Rational, Result, SRational, Value, IFD},
   lens::LensDescription,
-  tags::{ExifGpsTag, ExifTag},
+  tags::{DngTag, ExifGpsTag, ExifTag},
 };
 
 use std::convert::TryInto;
@@ -54,6 +54,9 @@ pub struct Exif {
   pub owner_name: Option<String>,
   pub serial_number: Option<String>,
   pub lens_serial_number: Option<String>,
+  pub dng_opcode_list_1: Option<Vec<u8>>,
+  pub dng_opcode_list_2: Option<Vec<u8>>,
+  pub dng_opcode_list_3: Option<Vec<u8>>,
   pub lens_make: Option<String>,
   pub lens_model: Option<String>,
   pub gps: Option<ExifGPS>,
@@ -161,6 +164,13 @@ impl Exif {
           (tag, _value) => {
             log::debug!("Ignoring EXIF tag: {:?}", tag);
           }
+        }
+      } else if let Ok(tag) = DngTag::try_from(*tag) {
+        match (tag, &entry.value) {
+          (DngTag::OpcodeList1, Value::Undefined(data)) => self.dng_opcode_list_1 = Some(data.clone()),
+          (DngTag::OpcodeList2, Value::Undefined(data)) => self.dng_opcode_list_2 = Some(data.clone()),
+          (DngTag::OpcodeList3, Value::Undefined(data)) => self.dng_opcode_list_3 = Some(data.clone()),
+          (_tag, _value) => {}
         }
       }
     }


### PR DESCRIPTION
The purpose of this change is to make the DNG OpcodeList tags available through the rawler API, so that they can be accessed from within vkdt to implement some opcode list processing for lens corrections.

It specifically gets the tags corresponding to the raw image, which might be in either Image or SubImage1, and ignores any OpcodeLists for preview / thumbnail images elsewhere in the file.

I also started writing a decoder in rust for the opcodes - can finish it and provide it if it would be useful for implementing opcode list processing in dnglab in the future.