### PR TITLE
crx: Use wrapping_shl() to prevent shl overflows in q_lookup()

### DIFF
--- a/rawler/src/decompressors/crx/iquant.rs
+++ b/rawler/src/decompressors/crx/iquant.rs
@@ -171,8 +171,13 @@ impl Tile {
             let mut row2_idx = qp_width * std::cmp::min(4 * qp_row + 2, qp_height - 1);
             let mut row3_idx = qp_width * std::cmp::min(4 * qp_row + 3, qp_height - 1);
             for _qp_col in 0..qp_width {
-              let mut quant_val = qp_table[row0_idx] + qp_table[row1_idx] + qp_table[row2_idx] + qp_table[row3_idx];
-              quant_val = ((quant_val.is_negative() as i32) * 3 + quant_val) >> 2;
+              let qp_sum = qp_table[row0_idx] + qp_table[row1_idx] + qp_table[row2_idx] + qp_table[row3_idx];
+              let quant_val = if qp_sum.is_negative() {
+                (qp_sum + 3) / 4 // Round?
+              } else {
+                qp_sum / 4
+              };
+
               let x = q_lookup(quant_val);
               //eprintln!("QSTEP 8: {:?}", x);
               q_step.q_step_tbl.push(x);

--- a/rawler/tests/issues/mod.rs
+++ b/rawler/tests/issues/mod.rs
@@ -23,3 +23,22 @@ fn dnglab_366_monochrome_dng_support() -> std::result::Result<(), Box<dyn std::e
   convert_raw_file(&path, &mut dng, &ConvertParams::default())?;
   Ok(())
 }
+
+#[test]
+fn dnglab_376_canon_crx_craw_qstep_shl_bug() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  {
+    let path = rawdb_file("issues/dnglab_376/Canon_EOS_R6M2_CRAW_ISO_25600.CR3");
+    let digest = raw_pixels_digest(&path, RawDecodeParams::default())?;
+    check_md5_equal(digest, "66c9fcb6541c90bdfb06d876be5984ec");
+    let mut dng = Cursor::new(Vec::new());
+    convert_raw_file(&path, &mut dng, &ConvertParams::default())?;
+  }
+  {
+    let path = rawdb_file("issues/dnglab_376/_MGC9382.CR3");
+    let digest = raw_pixels_digest(&path, RawDecodeParams::default())?;
+    check_md5_equal(digest, "aef96546a58e5265fb2f7b9e7498cbd0");
+    let mut dng = Cursor::new(Vec::new());
+    convert_raw_file(&path, &mut dng, &ConvertParams::default())?;
+  }
+  Ok(())
+}


### PR DESCRIPTION
This fixes #376 