### PR TITLE
fix: read correct markdown flag during lenses subcommand

### DIFF
--- a/bin/dnglab/dnglab-lib/src/app.rs
+++ b/bin/dnglab/dnglab-lib/src/app.rs
@@ -135,7 +135,7 @@ pub fn create_app() -> Command {
       Command::new("lenses")
         .about("List supported lenses")
         .arg_required_else_help(false)
-        .arg(arg!(--md "Markdown format output")),
+        .arg(arg!(markdown: --md "Markdown format output").action(ArgAction::SetTrue)),
     )
     .subcommand(
       Command::new("makedng")


### PR DESCRIPTION
Fixes #404 by setting the `markdown` identifier for the clap argument when setting up the CLI app.