### PR TITLE
Fix tiled DNG ljpeg92 decoding

### DIFF
--- a/rawler/src/decompressors/ljpeg/decompressors.rs
+++ b/rawler/src/decompressors/ljpeg/decompressors.rs
@@ -5,9 +5,9 @@ use crate::pumps::BitPumpMSB32;
 
 /// Decode the ljpeg stream to `out`.
 /// `x` is the start of output in `out`, usually 0.
-/// `stripwidth` is the widh of bytes of a single output strip (may
+/// `stripwidth` is the count of pixels of a single output strip (may
 /// be larger than width if each row has padding bytes).
-/// `width` is the output image width in bytes.
+/// `width` is the output image width in pixels.
 #[allow(clippy::let_and_return)]
 pub fn decode_ljpeg(ljpeg: &LjpegDecompressor, out: &mut [u16], x: usize, stripwidth: usize, width: usize, height: usize) -> Result<(), String> {
   let ncomp: usize = ljpeg.components();


### PR DESCRIPTION
Temporary tile may be larger than strip target. Usually this bug hits on lpjeg pred 4-7.

Related to issue #368 