### PR TITLE
FIX: DNG DefaultCropSize to Rect calculation

### DIFF
--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_647_20240229_000001_4k_12bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_647_20240229_000001_4k_12bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 3832
-          h: 2155
+          w: 3840
+          h: 2160
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_648_20240229_000001_4k_10bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_648_20240229_000001_4k_10bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 3832
-          h: 2155
+          w: 3840
+          h: 2160
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_650_20240229_000001_4k_8bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_650_20240229_000001_4k_8bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 3832
-          h: 2155
+          w: 3840
+          h: 2160
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_651_20240229_000001_2k_12bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_651_20240229_000001_2k_12bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 1912
-          h: 1075
+          w: 1920
+          h: 1080
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_652_20240229_000001_2k_10bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_652_20240229_000001_2k_10bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 1912
-          h: 1075
+          w: 1920
+          h: 1080
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_653_20240229_000001_2k_8bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_653_20240229_000001_2k_8bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 8
           y: 5
         d:
-          w: 1912
-          h: 1075
+          w: 1920
+          h: 1080
       activeArea:
         p:
           x: 0

--- a/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_6k_14bit.DNG.analyze.yaml
+++ b/rawler/data/testdata/cameras/Sigma/SIGMA fp/cinemadng/SIGMA_FP_6k_14bit.DNG.analyze.yaml
@@ -14,8 +14,8 @@ data:
           x: 32
           y: 21
         d:
-          w: 5968
-          h: 3979
+          w: 6000
+          h: 4000
       activeArea:
         p:
           x: 0

--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -18,6 +18,7 @@ use crate::formats::tiff::Rational;
 use crate::formats::tiff::Value;
 use crate::imgop::xyz::FlatColorMatrix;
 use crate::imgop::xyz::Illuminant;
+use crate::imgop::Dim2;
 use crate::imgop::Point;
 use crate::imgop::Rect;
 use crate::packed::*;
@@ -387,8 +388,8 @@ impl<'a> DngDecoder<'a> {
     if let Some(crops) = raw.get_entry(DngTag::DefaultCropOrigin) {
       let p = Point::new(crops.force_usize(0), crops.force_usize(1));
       if let Some(size) = raw.get_entry(DngTag::DefaultCropSize) {
-        let s = Point::new(size.force_usize(0), size.force_usize(1));
-        return Some(Rect::new_with_points(p, s));
+        let d = Dim2::new(size.force_usize(0), size.force_usize(1));
+        return Some(Rect::new(p, d));
       }
     }
     None


### PR DESCRIPTION
Because of this bug, converting a DNG file into a new DNG file shrinks the crop size.