### PR TITLE
Publish MacOS arm64 binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,27 @@ jobs:
           name: dnglab_x64
           path: 'target/release/dnglab'
 
+  macos_check:
+    name: MacOS check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check
+
+  macos_artifact:
+    name: MacOS release artifact (arm64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dnglab_arm64
+          path: 'target/release/dnglab'
+
 #  clippy:
 #    name: Clippy
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         include:
         - os: ubuntu-20.04
           install-deps: |
@@ -50,6 +50,11 @@ jobs:
         - os: windows-latest
           build-cmd: cargo build --release
           pkg-cmd: cd target/release/ && 7z a dnglab-win-x64_${GITHUB_REF#refs/*/}.zip dnglab.exe
+          package-files: target/release/dnglab*.zip
+
+        - os: macos-latest
+          build-cmd: cargo build --release
+          pkg-cmd: cd target/release/ && 7z a dnglab-macos-arm64_${GITHUB_REF#refs/*/}.zip dnglab
           package-files: target/release/dnglab*.zip
 
     steps:


### PR DESCRIPTION
* Created `macos_check` job, running on `macos-latest` executors.
* Created `macos_artifact` job, running on `macos-latest` executors.
* Added `macos-latest` to os matrix, with corresponding build and package commands.
* Tested binary against M1 `arm64` processor.