### PR TITLE
Add RawDecodeParams to Decoder::full_image()

### DIFF
--- a/bin/dnglab/dnglab-lib/src/makedng.rs
+++ b/bin/dnglab/dnglab-lib/src/makedng.rs
@@ -157,7 +157,7 @@ pub async fn makedng_internal(options: &ArgMatches, dest_path: &Path) -> crate::
   if let Ok(preview_input) = get_input_path(&inputs, &maps, InputUsage::Preview) {
     let mut rawfile = RawFile::new(preview_input, BufReader::new(File::open(preview_input)?));
     if let Ok(decoder) = get_decoder(&mut rawfile) {
-      if let Some(preview) = decoder.full_image(&mut rawfile)? {
+      if let Some(preview) = decoder.full_image(&mut rawfile, RawDecodeParams::default())? {
         let mut frame = dng.subframe(1);
         frame.preview(&preview, 0.7)?;
         frame.finalize()?;
@@ -175,7 +175,7 @@ pub async fn makedng_internal(options: &ArgMatches, dest_path: &Path) -> crate::
   if let Ok(thumbnail_input) = get_input_path(&inputs, &maps, InputUsage::Thumbnail) {
     let mut rawfile = RawFile::new(thumbnail_input, BufReader::new(File::open(thumbnail_input)?));
     if let Ok(decoder) = get_decoder(&mut rawfile) {
-      if let Some(preview) = decoder.full_image(&mut rawfile)? {
+      if let Some(preview) = decoder.full_image(&mut rawfile, RawDecodeParams::default())? {
         dng.thumbnail(&preview)?;
       }
     } else {

--- a/rawler/src/analyze.rs
+++ b/rawler/src/analyze.rs
@@ -212,34 +212,34 @@ pub fn extract_full_pixels<P: AsRef<Path>>(path: P, _params: RawDecodeParams) ->
   let input = BufReader::new(File::open(&path).map_err(|e| RawlerError::with_io_error("load buffer", &path, e))?);
   let mut rawfile = RawFile::new(path, input);
   let decoder = crate::get_decoder(&mut rawfile)?;
-  match decoder.full_image(&mut rawfile)? {
+  match decoder.full_image(&mut rawfile, RawDecodeParams::default())? {
     Some(preview) => Ok(preview),
     None => Err("Unable to extract full image from RAW".into()),
   }
 }
 
-pub fn extract_preview_pixels<P: AsRef<Path>>(path: P, _params: RawDecodeParams) -> Result<DynamicImage> {
+pub fn extract_preview_pixels<P: AsRef<Path>>(path: P, params: RawDecodeParams) -> Result<DynamicImage> {
   let input = BufReader::new(File::open(&path).map_err(|e| RawlerError::with_io_error("load buffer", &path, e))?);
   let mut rawfile = RawFile::new(path, input);
   let decoder = crate::get_decoder(&mut rawfile)?;
-  match decoder.preview_image(&mut rawfile)? {
+  match decoder.preview_image(&mut rawfile, params.clone())? {
     Some(preview) => Ok(preview),
-    None => match decoder.full_image(&mut rawfile)? {
+    None => match decoder.full_image(&mut rawfile, params)? {
       Some(preview) => Ok(preview),
       None => Err("Unable to extract preview image from RAW".into()),
     },
   }
 }
 
-pub fn extract_thumbnail_pixels<P: AsRef<Path>>(path: P, _params: RawDecodeParams) -> Result<DynamicImage> {
+pub fn extract_thumbnail_pixels<P: AsRef<Path>>(path: P, params: RawDecodeParams) -> Result<DynamicImage> {
   let input = BufReader::new(File::open(&path).map_err(|e| RawlerError::with_io_error("load buffer", &path, e))?);
   let mut rawfile = RawFile::new(path, input);
   let decoder = crate::get_decoder(&mut rawfile)?;
-  match decoder.thumbnail_image(&mut rawfile)? {
+  match decoder.thumbnail_image(&mut rawfile, params.clone())? {
     Some(thumbnail) => Ok(thumbnail),
-    None => match decoder.preview_image(&mut rawfile)? {
+    None => match decoder.preview_image(&mut rawfile, params.clone())? {
       Some(thumbnail) => Ok(thumbnail),
-      None => match decoder.full_image(&mut rawfile)? {
+      None => match decoder.full_image(&mut rawfile, params.clone())? {
         Some(thumbnail) => Ok(thumbnail),
         None => Err("Unable to extract thumbnail image from RAW".into()),
       },

--- a/rawler/src/decoders/arw.rs
+++ b/rawler/src/decoders/arw.rs
@@ -202,7 +202,10 @@ impl<'a> Decoder for ArwDecoder<'a> {
   /// Exiftool docs says there is a tag 0x2002 including the image, but this tag
   /// exists in none of the samples?! Instead, we can use the JPEG thumbnail
   /// tags which exists for most samples.
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     let root = self.tiff.root_ifd();
     if let Some(preview_off) = root.get_entry(ExifTag::JPEGInterchangeFormat) {
       if let Some(preview_len) = root.get_entry(ExifTag::JPEGInterchangeFormatLength) {

--- a/rawler/src/decoders/cr2.rs
+++ b/rawler/src/decoders/cr2.rs
@@ -306,7 +306,10 @@ impl<'a> Decoder for Cr2Decoder<'a> {
     Ok(self.xpacket.clone())
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     // For CR2, there is a full resolution image in IFD0.
     // This is compressed with old-JPEG compression (Compression = 6)
     let root_ifd = &self.tiff.root_ifd();

--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -385,7 +385,10 @@ impl<'a> Decoder for Cr3Decoder<'a> {
   }
 
   /// Extract preview image embedded in CR3
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     if rawler_ignore_previews() {
       return Err(RawlerError::DecoderFailed("Unable to extract preview image".into()));
     }

--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -110,7 +110,10 @@ impl<'a> Decoder for DngDecoder<'a> {
     Ok(mdata)
   }
 
-  fn thumbnail_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn thumbnail_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     if let Some(thumb_ifd) = Some(self.tiff.root_ifd()).filter(|ifd| ifd.get_entry(TiffCommonTag::NewSubFileType).map(|entry| entry.force_u32(0)) == Some(1)) {
       let buf = thumb_ifd
         .strip_data(file.inner())
@@ -133,7 +136,10 @@ impl<'a> Decoder for DngDecoder<'a> {
     Ok(None)
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     if let Some(sub_ifds) = self.tiff.root_ifd().get_sub_ifd_all(TiffCommonTag::SubIFDs) {
       let first_ifd = sub_ifds
         .iter()

--- a/rawler/src/decoders/mod.rs
+++ b/rawler/src/decoders/mod.rs
@@ -229,18 +229,18 @@ pub trait Decoder: Send {
   }
 
   // TODO: extend with decode params for image index
-  fn thumbnail_image(&self, _file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn thumbnail_image(&self, _file: &mut RawFile, _params: RawDecodeParams) -> Result<Option<DynamicImage>> {
     warn!("Decoder has no thumbnail image support, fallback to preview image");
     Ok(None)
   }
 
   // TODO: clarify preview and full image
-  fn preview_image(&self, _file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn preview_image(&self, _file: &mut RawFile, _params: RawDecodeParams) -> Result<Option<DynamicImage>> {
     warn!("Decoder has no preview image support");
     Ok(None)
   }
 
-  fn full_image(&self, _file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, _file: &mut RawFile, _params: RawDecodeParams) -> Result<Option<DynamicImage>> {
     warn!("Decoder has no full image support");
     Ok(None)
   }

--- a/rawler/src/decoders/nef.rs
+++ b/rawler/src/decoders/nef.rs
@@ -309,7 +309,10 @@ impl<'a> Decoder for NefDecoder<'a> {
     Ok(mdata)
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     let root_ifd = &self.tiff.root_ifd();
     if !root_ifd.contains_singlestrip_image() {
       // TODO: implement multistrip

--- a/rawler/src/decoders/pef.rs
+++ b/rawler/src/decoders/pef.rs
@@ -135,7 +135,10 @@ impl<'a> Decoder for PefDecoder<'a> {
     Ok(RawImage::new(self.camera.clone(), image, cpp, wb, photometric, blacklevel, whitelevel, dummy))
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     let size = self.makernote.get_entry(PefMakernote::PreviewImageSize);
     let length = self.makernote.get_entry(PefMakernote::PreviewImageLength);
     let start = self.makernote.get_entry(PefMakernote::PreviewImageStart);

--- a/rawler/src/decoders/raf.rs
+++ b/rawler/src/decoders/raf.rs
@@ -436,7 +436,10 @@ impl<'a> Decoder for RafDecoder<'a> {
     }
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     let jpeg_buf = self.read_embedded_jpeg(file)?;
     let img = image::load_from_memory_with_format(&jpeg_buf, image::ImageFormat::Jpeg).unwrap();
     Ok(Some(img))

--- a/rawler/src/decoders/rw2.rs
+++ b/rawler/src/decoders/rw2.rs
@@ -188,7 +188,10 @@ impl<'a> Decoder for Rw2Decoder<'a> {
     Ok(img)
   }
 
-  fn full_image(&self, _file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, _file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     if let Some(data) = self.tiff.get_entry(PanasonicTag::JpegData) {
       let buf = data.get_data();
       let img = image::load_from_memory_with_format(buf, image::ImageFormat::Jpeg)

--- a/rawler/src/decoders/tfr.rs
+++ b/rawler/src/decoders/tfr.rs
@@ -85,7 +85,10 @@ impl<'a> Decoder for TfrDecoder<'a> {
     Ok(img)
   }
 
-  fn full_image(&self, file: &mut RawFile) -> Result<Option<DynamicImage>> {
+  fn full_image(&self, file: &mut RawFile, params: RawDecodeParams) -> Result<Option<DynamicImage>> {
+    if params.image_index != 0 {
+      return Ok(None);
+    }
     let root_ifd = &self.tiff.root_ifd();
     let buf = root_ifd
       .singlestrip_data(file.inner())

--- a/rawler/src/dng/convert.rs
+++ b/rawler/src/dng/convert.rs
@@ -135,7 +135,7 @@ where
 
   // Write preview and thumbnail if requested
   if params.preview || params.thumbnail {
-    match generate_preview(&mut rawfile, decoder.as_ref(), &rawimage) {
+    match generate_preview(&mut rawfile, decoder.as_ref(), &rawimage, raw_params.clone()) {
       Ok(image) => {
         if params.preview {
           let mut preview = dng.subframe(1);
@@ -209,8 +209,8 @@ where
   Ok(())
 }
 
-fn generate_preview(rawfile: &mut RawFile, decoder: &dyn Decoder, rawimage: &RawImage) -> crate::Result<DynamicImage> {
-  match decoder.full_image(rawfile)? {
+fn generate_preview(rawfile: &mut RawFile, decoder: &dyn Decoder, rawimage: &RawImage, params: RawDecodeParams) -> crate::Result<DynamicImage> {
+  match decoder.full_image(rawfile, params)? {
     Some(image) => Ok(image),
     None => {
       log::warn!("Preview image not found, try to generate sRGB from RAW");

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -728,7 +728,7 @@ mod tests {
 
     let rawimage = decoder.raw_image(&mut rawfile, RawDecodeParams::default(), false)?;
 
-    let full_image = decoder.full_image(&mut rawfile)?.unwrap();
+    let full_image = decoder.full_image(&mut rawfile, RawDecodeParams::default())?.unwrap();
 
     let metadata = decoder.raw_metadata(&mut rawfile, RawDecodeParams::default())?;
 


### PR DESCRIPTION
Allow selection of specific full/preview image if raw file contains multiple frames

fixes #447