### PR TITLE
Add --keep-mtime flag

### DIFF
--- a/bin/dnglab/dnglab-lib/src/app.rs
+++ b/bin/dnglab/dnglab-lib/src/app.rs
@@ -85,6 +85,13 @@ pub fn create_app() -> Command {
         .value_parser(NonEmptyStringValueParser::new()),
     )
     .arg(
+      arg!(keep_mtime: --"keep-mtime" <keepmtime> "Keep mtime, read from EXIF with fallback to original file mtime")
+        .value_parser(ValueParser::bool())
+        .required(false)
+        .default_value("false")
+        .default_missing_value("false"),
+    )
+    .arg(
       arg!(index: --"image-index" <index> "Select a specific image index (or 'all') if file is a image container")
         .required(false)
         .default_value("0"),

--- a/bin/dnglab/dnglab-lib/src/convert.rs
+++ b/bin/dnglab/dnglab-lib/src/convert.rs
@@ -114,6 +114,7 @@ fn generate_job(entry: &FileMap, options: &ArgMatches) -> Result<Vec<Raw2DngJob>
       software: format!("{} {}", "DNGLab", PKG_VERSION),
       index: if do_batch { i } else { index },
       apply_scaling: false,
+      keep_mtime: options.get_flag("keep_mtime"),
     };
 
     let input = PathBuf::from(&entry.src);

--- a/rawler/src/dng/convert.rs
+++ b/rawler/src/dng/convert.rs
@@ -34,6 +34,7 @@ pub struct ConvertParams {
   pub artist: Option<String>,
   pub software: String,
   pub index: usize,
+  pub keep_mtime: bool,
 }
 
 impl Default for ConvertParams {
@@ -50,6 +51,7 @@ impl Default for ConvertParams {
       artist: None,
       software: "DNGLab".into(),
       index: 0,
+      keep_mtime: false,
     }
   }
 }


### PR DESCRIPTION
When converting raw files to DNG, each output file will get a new mtime.

With this new option, you can copy the Modifiy Time value (EXIF) from raw (or use the source mtime as fallback).