### PR TITLE
Add fixed lens support

### DIFF
--- a/rawler/data/cameras/canon/sx60hs.toml
+++ b/rawler/data/cameras/canon/sx60hs.toml
@@ -7,6 +7,9 @@ color_pattern = "RGGB"
 blackareav = [0, 70]
 active_area = [96, 16, 0, 0]
 
+[cameras.params]
+fixed_lens_key = "canon_powershot_sx60hs_lens"
+
 [cameras.color_matrix]
 A = [1.5686, -0.8326, -0.0246, -0.1888, 1.0463, 0.1645, 0.0286, 0.0708, 0.6145]
 D65 = [1.3161, -0.5451, -0.1344, -0.1989, 1.0654, 0.1531, -0.0047, 0.1271, 0.4955]

--- a/rawler/data/cameras/canon/sx70_hs.toml
+++ b/rawler/data/cameras/canon/sx70_hs.toml
@@ -4,6 +4,9 @@ clean_make = "Canon"
 clean_model = "PowerShot SX70 HS"
 color_pattern = "RGGB"
 
+[cameras.params]
+fixed_lens_key = "canon_powershot_sx70hs_lens"
+
 [cameras.color_matrix]
 A = [1.8214, -1.0357, 0.0257, -0.0756, 0.9461, 0.1536, 0.1018, 0.0228, 0.5656]
 D65 = [1.8285, -0.8907, -0.1951, -0.1845, 1.0688, 0.1323, 0.0364, 0.1101, 0.5139]

--- a/rawler/data/lenses/fixed/canon_fixed_lenses.toml
+++ b/rawler/data/lenses/fixed/canon_fixed_lenses.toml
@@ -1,0 +1,7 @@
+[[lenses]]
+mount = "fixed"
+make = "Canon"
+model = "PowerShot SX70 HS"
+focal_range = [[38, 10], [247, 1]]
+aperture_range = [[34, 10], [65, 10]]
+key = "canon_powershot_sx70hs_lens"

--- a/rawler/data/lenses/fixed/canon_fixed_lenses.toml
+++ b/rawler/data/lenses/fixed/canon_fixed_lenses.toml
@@ -5,3 +5,11 @@ model = "PowerShot SX70 HS"
 focal_range = [[38, 10], [247, 1]]
 aperture_range = [[34, 10], [65, 10]]
 key = "canon_powershot_sx70hs_lens"
+
+[[lenses]]
+mount = "fixed"
+make = "Canon"
+model = "PowerShot SX60 HS"
+focal_range = [[38, 10], [247, 1]]
+aperture_range = [[34, 10], [65, 10]]
+key = "canon_powershot_sx60hs_lens"

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX60 HS/raw_modes/Canon PowerShot SX60 HS_ISO_100_RAW.CR2.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX60 HS/raw_modes/Canon PowerShot SX60 HS_ISO_100_RAW.CR2.analyze.yaml
@@ -44,7 +44,11 @@ data:
         orientation: 1
         copyright: ""
         artist: ""
-        lens_spec: ~
+        lens_spec:
+          - 38/10
+          - 247/1
+          - 34/10
+          - 65/10
         exposure_time: 1/160
         fnumber: 45/10
         aperture_value: 139/32
@@ -82,8 +86,8 @@ data:
         owner_name: ""
         serial_number: ~
         lens_serial_number: ~
-        lens_make: ~
-        lens_model: ~
+        lens_make: Canon
+        lens_model: PowerShot SX60 HS
         gps:
           gps_version_id:
             - 2
@@ -124,7 +128,22 @@ data:
         user_comment: ~
       model: PowerShot SX60 HS
       make: Canon
-      lens: ~
+      lens:
+        identifiers:
+          name: canon_powershot_sx60hs_lens
+          id: ~
+          nikon_id: ~
+          olympus_id: ~
+        mount: fixed
+        lens_make: Canon
+        lens_model: PowerShot SX60 HS
+        focal_range:
+          - 38/10
+          - 247/1
+        aperture_range:
+          - 34/10
+          - 65/10
+        lens_name: Canon PowerShot SX60 HS
       unique_image_id: ~
       rating: ~
 

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX60 HS/raw_modes/RAW_CANON_POWERSHOT_SX60-HS.CR2.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX60 HS/raw_modes/RAW_CANON_POWERSHOT_SX60-HS.CR2.analyze.yaml
@@ -44,7 +44,11 @@ data:
         orientation: 1
         copyright: All rights reserved.
         artist: Christoph Schmidt
-        lens_spec: ~
+        lens_spec:
+          - 38/10
+          - 247/1
+          - 34/10
+          - 65/10
         exposure_time: 1/125
         fnumber: 56/10
         aperture_value: 159/32
@@ -82,8 +86,8 @@ data:
         owner_name: ""
         serial_number: ~
         lens_serial_number: ~
-        lens_make: ~
-        lens_model: ~
+        lens_make: Canon
+        lens_model: PowerShot SX60 HS
         gps:
           gps_version_id:
             - 2
@@ -130,7 +134,22 @@ data:
         user_comment: ~
       model: PowerShot SX60 HS
       make: Canon
-      lens: ~
+      lens:
+        identifiers:
+          name: canon_powershot_sx60hs_lens
+          id: ~
+          nikon_id: ~
+          olympus_id: ~
+        mount: fixed
+        lens_make: Canon
+        lens_model: PowerShot SX60 HS
+        focal_range:
+          - 38/10
+          - 247/1
+        aperture_range:
+          - 34/10
+          - 65/10
+        lens_name: Canon PowerShot SX60 HS
       unique_image_id: ~
       rating: ~
 

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_CRAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -44,7 +44,11 @@ data:
         orientation: 1
         copyright: CC-0
         artist: ""
-        lens_spec: ~
+        lens_spec:
+          - 38/10
+          - 247/1
+          - 34/10
+          - 65/10
         exposure_time: 16/10
         fnumber: 8/1
         aperture_value: 393216/65536
@@ -82,8 +86,8 @@ data:
         owner_name: ""
         serial_number: "852052000129"
         lens_serial_number: "0000000000"
-        lens_make: ~
-        lens_model: ~
+        lens_make: Canon
+        lens_model: PowerShot SX70 HS
         gps:
           gps_version_id:
             - 2
@@ -124,7 +128,22 @@ data:
         user_comment: ~
       model: PowerShot SX70 HS
       make: Canon
-      lens: ~
+      lens:
+        identifiers:
+          name: canon_powershot_sx70hs_lens
+          id: ~
+          nikon_id: ~
+          olympus_id: ~
+        mount: fixed
+        lens_make: Canon
+        lens_model: PowerShot SX70 HS
+        focal_range:
+          - 38/10
+          - 247/1
+        aperture_range:
+          - 34/10
+          - 65/10
+        lens_name: Canon PowerShot SX70 HS
       unique_image_id: 160641590480834242587348364450592529350
       rating: ~
 

--- a/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
+++ b/rawler/data/testdata/cameras/Canon/PowerShot SX70 HS/raw_modes/Canon PowerShot SX70 HS_RAW_ISO_100_nocrop_nodual.CR3.analyze.yaml
@@ -44,7 +44,11 @@ data:
         orientation: 1
         copyright: CC-0
         artist: ""
-        lens_spec: ~
+        lens_spec:
+          - 38/10
+          - 247/1
+          - 34/10
+          - 65/10
         exposure_time: 6/10
         fnumber: 8/1
         aperture_value: 393216/65536
@@ -82,8 +86,8 @@ data:
         owner_name: ""
         serial_number: "852052000129"
         lens_serial_number: "0000000000"
-        lens_make: ~
-        lens_model: ~
+        lens_make: Canon
+        lens_model: PowerShot SX70 HS
         gps:
           gps_version_id:
             - 2
@@ -124,7 +128,22 @@ data:
         user_comment: ~
       model: PowerShot SX70 HS
       make: Canon
-      lens: ~
+      lens:
+        identifiers:
+          name: canon_powershot_sx70hs_lens
+          id: ~
+          nikon_id: ~
+          olympus_id: ~
+        mount: fixed
+        lens_make: Canon
+        lens_model: PowerShot SX70 HS
+        focal_range:
+          - 38/10
+          - 247/1
+        aperture_range:
+          - 34/10
+          - 65/10
+        lens_name: Canon PowerShot SX70 HS
       unique_image_id: 160641590480834242587348364450635388982
       rating: ~
 

--- a/rawler/src/decoders/arw.rs
+++ b/rawler/src/decoders/arw.rs
@@ -253,6 +253,7 @@ impl<'a> ArwDecoder<'a> {
       debug!("Lens Id tag: {}", lens_id);
 
       let resolver = LensResolver::new()
+        .with_camera(&self.camera)
         .with_lens_id((lens_id as u32, 0))
         .with_mounts(&[SONY_E_MOUNT.into(), SONY_A_MOUNT.into()]);
       return Ok(resolver.resolve());
@@ -270,6 +271,7 @@ impl<'a> ArwDecoder<'a> {
         debug!("Lens Id tag: {}", lens_id);
 
         let resolver = LensResolver::new()
+          .with_camera(&self.camera)
           .with_lens_id((lens_id as u32, 0))
           .with_mounts(&[SONY_E_MOUNT.into(), SONY_A_MOUNT.into()]);
         return Ok(resolver.resolve());
@@ -287,6 +289,7 @@ impl<'a> ArwDecoder<'a> {
       debug!("Lens Id tag: {}", lens_id);
 
       let resolver = LensResolver::new()
+        .with_camera(&self.camera)
         .with_lens_id((lens_id as u32, 0))
         .with_mounts(&[SONY_E_MOUNT.into(), SONY_A_MOUNT.into()]);
       return Ok(resolver.resolve());

--- a/rawler/src/decoders/cr2.rs
+++ b/rawler/src/decoders/cr2.rs
@@ -445,6 +445,7 @@ impl<'a> Cr2Decoder<'a> {
         debug!("Lens Info tag: {}", lens_info);
         let resolver = LensResolver::new()
           .with_lens_keyname(exif_lens_name)
+          .with_camera(&self.camera) // must follow with_lens_keyname() as it my override key
           .with_lens_id((lens_info as u32, 0))
           .with_focal_len(self.get_focal_len()?)
           .with_mounts(&[CANON_CN_MOUNT.into(), CANON_EF_MOUNT.into()]);

--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -448,6 +448,7 @@ impl<'a> Cr3Decoder<'a> {
 
     let resolver = LensResolver::new()
       .with_lens_keyname(self.read_lens_name()?)
+      .with_camera(&self.camera) // must follow with_lens_keyname() as it my override key
       .with_lens_id(self.read_lens_id()?)
       .with_mounts(&[CANON_CN_MOUNT.into(), CANON_EF_MOUNT.into(), CANON_RF_MOUNT.into()]);
     md.lens_description = resolver.resolve();

--- a/rawler/src/decoders/iiq.rs
+++ b/rawler/src/decoders/iiq.rs
@@ -973,7 +973,7 @@ impl<'a> IiqDecoder<'a> {
   fn get_lens_description(&self) -> Result<Option<&'static LensDescription>> {
     match self.lens_model()? {
       Some(model) => {
-        let resolver = LensResolver::new().with_camera(&self.camera).with_lens_keyname(Some(model));
+        let resolver = LensResolver::new().with_lens_keyname(Some(model)).with_camera(&self.camera);
         Ok(resolver.resolve())
       }
       None => Ok(None),

--- a/rawler/src/decoders/nef.rs
+++ b/rawler/src/decoders/nef.rs
@@ -375,11 +375,17 @@ impl<'a> NefDecoder<'a> {
           NefLensData::FMount(oldv) => {
             let composite_id = oldv.composite_id(lenstype.force_u8(0));
             log::debug!("NEF lens composite ID: {}", composite_id);
-            let resolver = LensResolver::new().with_nikon_id(Some(composite_id)).with_mounts(&[NIKON_F_MOUNT.into()]);
+            let resolver = LensResolver::new()
+              .with_nikon_id(Some(composite_id))
+              .with_camera(&self.camera)
+              .with_mounts(&[NIKON_F_MOUNT.into()]);
             return Ok(resolver.resolve());
           }
           NefLensData::ZMount(newv) => {
-            let resolver = LensResolver::new().with_lens_id((newv.lens_id as u32, 0)).with_mounts(&[NIKON_Z_MOUNT.into()]);
+            let resolver = LensResolver::new()
+              .with_lens_id((newv.lens_id as u32, 0))
+              .with_camera(&self.camera)
+              .with_mounts(&[NIKON_Z_MOUNT.into()]);
             return Ok(resolver.resolve());
           }
         }

--- a/rawler/src/decoders/orf.rs
+++ b/rawler/src/decoders/orf.rs
@@ -367,6 +367,7 @@ impl<'a> OrfDecoder<'a> {
           log::debug!("ORF lens composite ID: {}", composite_id);
           let resolver = LensResolver::new()
             .with_olympus_id(Some(composite_id))
+            .with_camera(&self.camera)
             .with_focal_len(self.get_focal_len()?)
             .with_mounts(&[MFT_MOUNT.into()]);
           return Ok(resolver.resolve());

--- a/rawler/src/decoders/rw2.rs
+++ b/rawler/src/decoders/rw2.rs
@@ -277,6 +277,7 @@ impl<'a> Rw2Decoder<'a> {
           );
           log::debug!("RW2 lens composite ID: {}", composite_id);
           let resolver = LensResolver::new()
+            .with_camera(&self.camera)
             .with_olympus_id(Some(composite_id))
             .with_focal_len(self.get_focal_len()?)
             .with_mounts(&[MFT_MOUNT.into()]);

--- a/rawler/src/decoders/srw.rs
+++ b/rawler/src/decoders/srw.rs
@@ -461,7 +461,10 @@ impl<'a> SrwDecoder<'a> {
   fn get_lens_description(&self) -> Result<Option<&'static LensDescription>> {
     if let Some(lens_id) = self.makernote.get_entry(SrwMakernote::LensModel) {
       let lens_id = lens_id.force_u16(0);
-      let resolver = LensResolver::new().with_lens_id((lens_id.into(), 0)).with_mounts(&[NX_MOUNT.into()]);
+      let resolver = LensResolver::new()
+        .with_lens_id((lens_id.into(), 0))
+        .with_camera(&self.camera)
+        .with_mounts(&[NX_MOUNT.into()]);
       return Ok(resolver.resolve());
     }
     Ok(None)

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -718,7 +718,7 @@ mod tests {
     };
 
     let mut rawdb = PathBuf::from(std::env::var("RAWLER_RAWDB").expect("RAWLER_RAWDB variable must be set in order to run RAW test!"));
-    rawdb.push("cameras/Canon/EOS R5/raw_modes/Canon EOS R5_RAW_ISO_100_nocrop_nodual.CR3");
+    rawdb.push("cameras/Canon/EOS R6/raw_modes/Canon EOS R6_RAW_ISO_100_nocrop_nodual.CR3");
 
     let rawfile = RawSource::new(&rawdb)?;
 


### PR DESCRIPTION
Some cameras (bridge cameras) has fixed lenses. The lens resolver can't find matching lenses because fixed lenses are not yet added to the lens database.
This PR adds experimental support for fixed lenses for two cameras:
 * Canon PowerShot SX60 HS
 * Canon PowerShot SX70 HS

closes #503