### PR TITLE
Add model alias for Panasonic DMC-ZS50

### DIFF
--- a/rawler/data/cameras/panasonic/tz70.toml
+++ b/rawler/data/cameras/panasonic/tz70.toml
@@ -2,6 +2,11 @@ make = "Panasonic"
 model = "DMC-TZ70"
 clean_make = "Panasonic"
 clean_model = "DMC-TZ70"
+
+model_aliases = [
+  ["DMC-ZS50", "DMC-ZS50"],
+]
+
 #blackpoint = 143
 whitepoint = 3971
 color_pattern = "RGGB"


### PR DESCRIPTION
The Panasonic DMC-ZS50 is equivalent to the DMC-TZ70, but there is no alias set up for it. This PR just fills in that alias.

I'm not particularly familiar with the project; I'm happy to provide raws to set up a testcase if necessary.