### PR TITLE
Remove Warnings About Elided Lifetime

### DIFF
--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -454,11 +454,11 @@ where
     Ok(())
   }
 
-  pub fn subframe(&mut self, id: u32) -> SubFrameWriter<B> {
+  pub fn subframe(&mut self, id: u32) -> SubFrameWriter<'_, B> {
     SubFrameWriter::new(self, id, false)
   }
 
-  pub fn subframe_on_root(&mut self, id: u32) -> SubFrameWriter<B> {
+  pub fn subframe_on_root(&mut self, id: u32) -> SubFrameWriter<'_, B> {
     SubFrameWriter::new(self, id, true)
   }
 

--- a/rawler/src/lens.rs
+++ b/rawler/src/lens.rs
@@ -152,7 +152,7 @@ impl LensResolver {
     self
   }
 
-  fn lens_matcher(&self) -> LensMatcher {
+  fn lens_matcher(&self) -> LensMatcher<'_> {
     LensMatcher {
       lens_name: self.lens_keyname.as_deref(),
       lens_make: self.lens_make.as_deref(),

--- a/rawler/src/pixarray.rs
+++ b/rawler/src/pixarray.rs
@@ -121,12 +121,12 @@ where
     &mut self.data
   }
 
-  pub fn pixel_rows(&self) -> std::slice::ChunksExact<T> {
+  pub fn pixel_rows(&self) -> std::slice::ChunksExact<'_, T> {
     debug_assert!(self.initialized);
     self.data.chunks_exact(self.width)
   }
 
-  pub fn pixel_rows_mut(&mut self) -> std::slice::ChunksExactMut<T> {
+  pub fn pixel_rows_mut(&mut self) -> std::slice::ChunksExactMut<'_, T> {
     debug_assert!(self.initialized);
     self.data.chunks_exact_mut(self.width)
   }
@@ -406,11 +406,11 @@ where
     &mut self.data
   }
 
-  pub fn pixel_rows(&self) -> std::slice::ChunksExact<[T; N]> {
+  pub fn pixel_rows(&self) -> std::slice::ChunksExact<'_, [T; N]> {
     self.data.chunks_exact(self.width)
   }
 
-  pub fn pixel_rows_mut(&mut self) -> std::slice::ChunksExactMut<[T; N]> {
+  pub fn pixel_rows_mut(&mut self) -> std::slice::ChunksExactMut<'_, [T; N]> {
     self.data.chunks_exact_mut(self.width)
   }
 

--- a/rawler/src/rawsource.rs
+++ b/rawler/src/rawsource.rs
@@ -76,7 +76,7 @@ impl RawSource {
     ))
   }
 
-  pub fn subview_padded(&self, offset: u64, size: u64) -> std::io::Result<PaddedBuf> {
+  pub fn subview_padded(&self, offset: u64, size: u64) -> std::io::Result<PaddedBuf<'_>> {
     if offset + size <= self.len() as u64 {
       if offset + size + 16 <= self.len() as u64 {
         self.subview(offset, size + 16).map(|buf| PaddedBuf::new_ref(buf, size as usize))
@@ -101,7 +101,7 @@ impl RawSource {
     ))
   }
 
-  pub fn subview_until_eof_padded(&self, offset: u64) -> std::io::Result<PaddedBuf> {
+  pub fn subview_until_eof_padded(&self, offset: u64) -> std::io::Result<PaddedBuf<'_>> {
     if offset < self.len() as u64 {
       let mut buf = Vec::with_capacity((self.len() - offset as usize + 16) as usize);
       buf.extend_from_slice(self.subview_until_eof(offset)?);


### PR DESCRIPTION
This trivially gets rid of nine warnings about hidden lifetimes by simply adding placeholders for them.