### PR TITLE
fix(demosaic): Fix panic when processing images with odd widths

### DIFF
--- a/rawler/src/imgop/sensor/bayer/mod.rs
+++ b/rawler/src/imgop/sensor/bayer/mod.rs
@@ -27,7 +27,6 @@ fn expand_bayer_rgb(raw: &[f32], dim: Dim2, cfa: &CFA, roi: Rect) -> RgbF32 {
   let cfa_roi = cfa.shift(roi.x(), roi.y());
   let mut out = RgbF32::new(roi.width(), roi.height());
   out.pixels_mut().par_chunks_exact_mut(roi.width()).enumerate().for_each(|(row_out, buf)| {
-    assert_eq!(roi.width() % cfa.width, 0); // Area must be bound to CFA bounds
     let row_in = roi.p.y + row_out;
     let start_in = row_in * dim.w + roi.p.x;
     let line = &raw[start_in..start_in + roi.width()];


### PR DESCRIPTION
Hi @cytrinox,

This PR fixes a panic that occurs when demosaicing RAW files that have an odd-numbered width (See https://github.com/dnglab/dnglab/issues/651 or https://github.com/CyberTimon/RapidRAW/issues/612).

The `expand_bayer_rgb` function currently has an assertion that requires the image's ROI width to be an even number:
```rust
assert_eq!(roi.width() % cfa.width, 0); // Area must be bound to CFA bounds
```
This causes a panic when processing valid RAW files from cameras that produce odd-width images, such as some Canon CR3 files. I encountered this with the file `M3T_7887.CR3` (from issue https://github.com/dnglab/dnglab/issues/651), which triggered the following error:
```
PANIC! at rawler\rawler\src\imgop\sensor\bayer\mod.rs:30:5 - assertion `left == right` failed
  left: 1
 right: 0
```

The pixel-processing loop that follows the assertion is perfectly capable of handling odd-width images, as it iterates pixel by pixel and uses `cfa_roi.color_at(row_out, col)` to determine the correct color plane.

This PR simply removes the unnecessary assertion, allowing the function to correctly process images of any width, whether even or odd.

This should improve compatibility with a wider range of RAW files without any negative side effects.

Let me know what you think.

Kind regards,
Timon