### PR TITLE
Added 250D alias for Asia region (EOS 200D II)

### DIFF
--- a/rawler/data/cameras/canon/250d.toml
+++ b/rawler/data/cameras/canon/250d.toml
@@ -5,7 +5,8 @@ clean_model = "EOS 250D"
 color_pattern = "RGGB"
 
 model_aliases = [
-  ["Canon EOS Rebel SL3", "Rebel SL3"],
+  ["Canon EOS Rebel SL3", "EOS Rebel SL3"],
+  ["Canon EOS Kiss X10", "EOS Kiss X10"],
   ["Canon EOS 200D II", "EOS 200D II"]
 ]
 


### PR DESCRIPTION
The EOS 250D is called the EOS 200D II in the Asia region. Any conversion on the current build fails with unknown camera. I've confirmed adding the alias works properly by using a local build