### PR TITLE
Remove bogus Canon EOS aliases

### DIFF
--- a/rawler/data/cameras/canon/1000d.toml
+++ b/rawler/data/cameras/canon/1000d.toml
@@ -5,8 +5,6 @@ clean_model = "EOS 1000D"
 
 model_aliases = [
   ["Canon EOS DIGITAL REBEL XS", "EOS Digital Rebel XS"],
-  ["Canon EOS REBEL XS", "EOS Rebel XS"],
-  ["Canon EOS Kiss Digital F", "EOS Kiss F"],
   ["Canon EOS Kiss F", "EOS Kiss F"],
 ]
 

--- a/rawler/data/cameras/canon/100d.toml
+++ b/rawler/data/cameras/canon/100d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 100D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL SL1", "EOS Rebel SL1"],
   ["Canon EOS REBEL SL1", "EOS Rebel SL1"],
-  ["Canon EOS Kiss Digital X7", "EOS Kiss X7"],
   ["Canon EOS Kiss X7", "EOS Kiss X7"],
 ]
 

--- a/rawler/data/cameras/canon/1100d.toml
+++ b/rawler/data/cameras/canon/1100d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 1100D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T3", "EOS Rebel T3"],
   ["Canon EOS REBEL T3", "EOS Rebel T3"],
-  ["Canon EOS Kiss Digital X50", "EOS Kiss X50"],
   ["Canon EOS Kiss X50", "EOS Kiss X50"],
 ]
 

--- a/rawler/data/cameras/canon/1200d.toml
+++ b/rawler/data/cameras/canon/1200d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 1200D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T5", "EOS Rebel T5"],
   ["Canon EOS REBEL T5", "EOS Rebel T5"],
-  ["Canon EOS Kiss Digital X70", "EOS Kiss X70"],
   ["Canon EOS Kiss X70", "EOS Kiss X70"],
   ["Canon EOS Hi", "EOS Hi"],
 ]

--- a/rawler/data/cameras/canon/1300d.toml
+++ b/rawler/data/cameras/canon/1300d.toml
@@ -4,10 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 1300D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T6", "EOS Rebel T6"],
-  ["Canon EOS REBEL T6", "EOS Rebel T6"],
   ["Canon EOS Rebel T6", "EOS Rebel T6"],
-  ["Canon EOS Kiss Digital X80", "EOS Kiss X80"],
   ["Canon EOS Kiss X80", "EOS Kiss X80"],
 ]
 

--- a/rawler/data/cameras/canon/2000d.toml
+++ b/rawler/data/cameras/canon/2000d.toml
@@ -7,7 +7,6 @@ active_area = [88, 47, 0, 0]
 
 model_aliases = [
   ["Canon EOS 1500D", "EOS 1500D"],
-  ["Canon EOS REBEL T7", "EOS Rebel T7"],
   ["Canon EOS Rebel T7", "EOS Rebel T7"],
   ["Canon EOS Kiss X90", "EOS Kiss X90"],
 ]

--- a/rawler/data/cameras/canon/200d.toml
+++ b/rawler/data/cameras/canon/200d.toml
@@ -5,6 +5,7 @@ clean_model = "EOS 200D"
 
 model_aliases = [
   ["Canon EOS Kiss X9", "EOS Kiss X9"],
+  ["Canon EOS REBEL SL2", "EOS Rebel SL2"],
   ["Canon EOS Rebel SL2", "EOS Rebel SL2"],
 ]
 

--- a/rawler/data/cameras/canon/300d.toml
+++ b/rawler/data/cameras/canon/300d.toml
@@ -5,11 +5,8 @@ clean_make = "Canon"
 clean_model = "EOS 300D"
 
 model_aliases = [
-  ["Canon EOS 300D Digital", "EOS 300D"],
   ["Canon EOS DIGITAL REBEL", "EOS Digital Rebel"],
-  ["Canon EOS REBEL", "EOS Rebel"],
   ["Canon EOS Kiss Digital", "EOS Kiss Digital"],
-  ["Canon EOS Kiss", "EOS Kiss"],
 ]
 
 whitepoint = 4000

--- a/rawler/data/cameras/canon/350d.toml
+++ b/rawler/data/cameras/canon/350d.toml
@@ -4,11 +4,8 @@ clean_make = "Canon"
 clean_model = "EOS 350D"
 
 model_aliases = [
-  ["Canon EOS 350D Digital", "EOS 350D"],
   ["Canon EOS DIGITAL REBEL XT", "EOS Digital Rebel XT"],
-  ["Canon EOS REBEL XT", "EOS Rebel XT"],
   ["Canon EOS Kiss Digital N", "EOS Kiss Digital N"],
-  ["Canon EOS Kiss N", "EOS Kiss N"],
 ]
 
 whitepoint = 4095

--- a/rawler/data/cameras/canon/400d.toml
+++ b/rawler/data/cameras/canon/400d.toml
@@ -5,9 +5,7 @@ clean_model = "EOS 400D"
 
 model_aliases = [
   ["Canon EOS DIGITAL REBEL XTi", "EOS Digital Rebel XTi"],
-  ["Canon EOS REBEL XTi", "EOS Rebel XTi"],
   ["Canon EOS Kiss Digital X", "EOS Kiss Digital X"],
-  ["Canon EOS Kiss X", "EOS Kiss X"],
 ]
 
 whitepoint = 4058

--- a/rawler/data/cameras/canon/450d.toml
+++ b/rawler/data/cameras/canon/450d.toml
@@ -5,8 +5,6 @@ clean_model = "EOS 450D"
 
 model_aliases = [
   ["Canon EOS DIGITAL REBEL XSi", "EOS Digital Rebel XSi"],
-  ["Canon EOS REBEL XSi", "EOS Rebel XSi"],
-  ["Canon EOS Kiss Digital X2", "EOS Kiss X2"],
   ["Canon EOS Kiss X2", "EOS Kiss X2"],
 ]
 

--- a/rawler/data/cameras/canon/500d.toml
+++ b/rawler/data/cameras/canon/500d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 500D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T1i", "EOS Rebel T1i"],
   ["Canon EOS REBEL T1i", "EOS Rebel T1i"],
-  ["Canon EOS Kiss Digital X3", "EOS Kiss X3"],
   ["Canon EOS Kiss X3", "EOS Kiss X3"],
 ]
 

--- a/rawler/data/cameras/canon/550d.toml
+++ b/rawler/data/cameras/canon/550d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 550D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T2i", "EOS Rebel T2i"],
   ["Canon EOS REBEL T2i", "EOS Rebel T2i"],
-  ["Canon EOS Kiss Digital X4", "EOS Kiss X4"],
   ["Canon EOS Kiss X4", "EOS Kiss X4"],
 ]
 

--- a/rawler/data/cameras/canon/600d.toml
+++ b/rawler/data/cameras/canon/600d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 600D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T3i", "EOS Rebel T3i"],
   ["Canon EOS REBEL T3i", "EOS Rebel T3i"],
-  ["Canon EOS Kiss Digital X5", "EOS Kiss X5"],
   ["Canon EOS Kiss X5", "EOS Kiss X5"],
 ]
 

--- a/rawler/data/cameras/canon/650d.toml
+++ b/rawler/data/cameras/canon/650d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 650D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T4i", "EOS Rebel T4i"],
   ["Canon EOS REBEL T4i", "EOS Rebel T4i"],
-  ["Canon EOS Kiss Digital X6i", "EOS Kiss X6i"],
   ["Canon EOS Kiss X6i", "EOS Kiss X6i"],
 ]
 

--- a/rawler/data/cameras/canon/700d.toml
+++ b/rawler/data/cameras/canon/700d.toml
@@ -4,9 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 700D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T5i", "EOS Rebel T5i"],
   ["Canon EOS REBEL T5i", "EOS Rebel T5i"],
-  ["Canon EOS Kiss Digital X7i", "EOS Kiss X7i"],
   ["Canon EOS Kiss X7i", "EOS Kiss X7i"],
 ]
 

--- a/rawler/data/cameras/canon/750d.toml
+++ b/rawler/data/cameras/canon/750d.toml
@@ -4,10 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 750D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T6i", "EOS Rebel T6i"],
-  ["Canon EOS REBEL T6i", "EOS Rebel T6i"],
   ["Canon EOS Rebel T6i", "EOS Rebel T6i"],
-  ["Canon EOS Kiss Digital X8i", "EOS Kiss X8i"],
   ["Canon EOS Kiss X8i", "EOS Kiss X8i"],
 ]
 

--- a/rawler/data/cameras/canon/760d.toml
+++ b/rawler/data/cameras/canon/760d.toml
@@ -4,7 +4,6 @@ clean_make = "Canon"
 clean_model = "EOS 760D"
 
 model_aliases = [
-  ["Canon EOS DIGITAL REBEL T6s", "EOS Rebel T6s"],
   ["Canon EOS Rebel T6s", "EOS Rebel T6s"],
   ["Canon EOS 8000D", "EOS 8000D"],
 ]


### PR DESCRIPTION
Collated from various sources (and of course RPU):

https://global.canon/en/c-museum/camera.html?s=all
https://helpx.adobe.com/camera-raw/kb/camera-raw-plug-supported-cameras.html
https://www.libraw.org/supported-cameras

AFAIK only "EOS Rebel SL2" and "EOS Rebel T7i" had the REBEL/Rebel duplication for some firmware versions...