### PR TITLE
Use aperture and focal length for CR3 lens resolver

### DIFF
--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -455,13 +455,6 @@ impl<'a> Cr3Decoder<'a> {
     }
     let mut md = Cr3Metadata::default();
 
-    let resolver = LensResolver::new()
-      .with_lens_keyname(self.read_lens_name()?)
-      .with_camera(&self.camera) // must follow with_lens_keyname() as it my override key
-      .with_lens_id(self.read_lens_id()?)
-      .with_mounts(&[CANON_CN_MOUNT.into(), CANON_EF_MOUNT.into(), CANON_RF_MOUNT.into()]);
-    md.lens_description = resolver.resolve();
-
     if let Some(Entry {
       value: crate::formats::tiff::Value::Byte(v),
       ..
@@ -547,6 +540,15 @@ impl<'a> Cr3Decoder<'a> {
         md.ctmd_rec9 = Some(rec9);
       }
     }
+
+    let resolver = LensResolver::new()
+      .with_lens_keyname(self.read_lens_name()?)
+      .with_camera(&self.camera) // must follow with_lens_keyname() as it my override key
+      .with_lens_id(self.read_lens_id()?)
+      .with_aperture(md.ctmd_exposure.as_ref().map(|x| x.fnumber.clone()))
+      .with_focal_len(md.ctmd_focallen.clone())
+      .with_mounts(&[CANON_CN_MOUNT.into(), CANON_EF_MOUNT.into(), CANON_RF_MOUNT.into()]);
+    md.lens_description = resolver.resolve();
 
     debug!("CR3 blacklevels: {:?}", md.blacklevels);
     debug!("CR3 whitelevel: {:?}", md.whitelevel);

--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -3,6 +3,7 @@
 
 use image::DynamicImage;
 use log::{debug, warn};
+use num::Zero;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 
@@ -678,8 +679,15 @@ impl Ctmd {
 
   pub fn focal_len(&self) -> Result<Option<Rational>> {
     if let Some(rec) = self.records.get(&4) {
+      if rec.payload.len() < 4 {
+        return Ok(None)
+      }
       let mut buf = ByteStream::new(rec.payload.as_slice(), Endian::Little);
       let focal_len = Rational::new(buf.get_u16().into(), buf.get_u16().into());
+      if focal_len.d.is_zero() {
+        // Canon EOS R_RAW_ISO_100_nocrop_nodual.CR3 has an invalid Rational value
+        return Ok(None);
+      }
       Ok(Some(focal_len))
     } else {
       Ok(None)

--- a/rawler/src/lens.rs
+++ b/rawler/src/lens.rs
@@ -242,10 +242,7 @@ impl LensResolver {
           .is_none_or(|focal| *focal >= entry.focal_range[0] && *focal <= entry.focal_range[1])
       })
       .filter(|entry| {
-        self
-          .aperture
-          .as_ref()
-          .is_none_or(|ap| *ap >= entry.aperture_range[0] || *ap <= entry.aperture_range[1])
+        self.aperture.as_ref().is_none_or(|ap| *ap >= entry.aperture_range[0]) // equal or greater then lowest possible aperture
       })
       .collect();
     match matches.len() {


### PR DESCRIPTION
We could improve lens detection when using focal length and aperture in CR3 metadata decoder.