### PR TITLE
fix(demosaic): Correct PPG gradient calculations and artifacts

### DIFF
--- a/rawler/src/imgop/sensor/bayer/ppg.rs
+++ b/rawler/src/imgop/sensor/bayer/ppg.rs
@@ -134,10 +134,10 @@ fn interpolate_green(img: &mut RgbF32, shifted: &CFA) {
         let w_2 = unsafe { dataptr.at(row, col - 2)[ch] };
 
         // Calculate the gradients for each direction.
-        let n = (x - n_2).abs() * 2.0 + (n_1 - s_1);
-        let e = (x - e_2).abs() * 2.0 + (w_1 - e_1);
-        let w = (x - w_2).abs() * 2.0 + (w_1 - e_1);
-        let s = (x - s_2).abs() * 2.0 + (n_1 - s_1);
+        let n = (x - n_2).abs() * 2.0 + (n_1 - s_1).abs();
+        let e = (x - e_2).abs() * 2.0 + (w_1 - e_1).abs();
+        let w = (x - w_2).abs() * 2.0 + (w_1 - e_1).abs();
+        let s = (x - s_2).abs() * 2.0 + (n_1 - s_1).abs();
 
         // Find the minimum value of the gradients.
         let mut min = n;
@@ -238,7 +238,7 @@ fn interpolate_rb_at_non_green(img: &mut RgbF32, shifted: &CFA) {
 
         let ne = (y_ne_1 - y_sw_1).abs() + (x_ne_2 - x_center).abs() + (x_center - x_sw_2).abs() + (g_ne_1 - g_center).abs() + (g_center - g_sw_1).abs();
 
-        let nw = (y_nw_1 - y_se_1).abs() + (x_nw_2 - x_center).abs() + (x_center - x_se_2).abs() + (g_nw_1 + g_center).abs() + (g_center - g_se_1).abs();
+        let nw = (y_nw_1 - y_se_1).abs() + (x_nw_2 - x_center).abs() + (x_center - x_se_2).abs() + (g_nw_1 - g_center).abs() + (g_center - g_se_1).abs();
 
         pixel[y_ch] = if ne < nw {
           hue_transit(g_ne_1, g_center, g_sw_1, y_ne_1, y_sw_1)


### PR DESCRIPTION
Hi @cytrinox 

This PR fixes checkerboard and zipper artifacts (as described [here](https://github.com/CyberTimon/RapidRAW/issues/1032)) by correcting two mathematical typos in the gradient logic:

*   **`interpolate_green`:** Added missing `.abs()` to directional gradients. Previously, negative values were incorrectly picked as the "minimum" gradient, causing interpolation across edges.
*   **`interpolate_rb_at_non_green`:** Fixed a `+` that should have been a `-`. This was inflating the NW gradient and causing a heavy directional bias on diagonals.

Comparison:
| Before | After |
| :---: | :---: |
| <img width="1500" alt="Before fix" src="https://github.com/user-attachments/assets/ff279f42-1f62-4c6d-acfd-c41a50745329" /> | <img width="1500" alt="After fix" src="https://github.com/user-attachments/assets/e31054a1-e418-43d6-8c4a-c7d2390b1a06" /> |

I recommend to open both images in seperate tabs and switch between them. It's a bit hard to see but you can easily spot the artifacts when comparing these areas:

<img width="484" height="385" alt="Image" src="https://github.com/user-attachments/assets/36448b94-1214-4015-a9e7-e26ca0aee607" />

Thanks for taking a look & tell me when you need any changes.

Have a nice evening,
Timon