### PR TITLE
Restore Canon EOS 350D alias

### DIFF
--- a/rawler/data/cameras/canon/350d.toml
+++ b/rawler/data/cameras/canon/350d.toml
@@ -4,6 +4,7 @@ clean_make = "Canon"
 clean_model = "EOS 350D"
 
 model_aliases = [
+  ["Canon EOS 350D Digital", "EOS 350D"],
   ["Canon EOS DIGITAL REBEL XT", "EOS Digital Rebel XT"],
   ["Canon EOS Kiss Digital N", "EOS Kiss Digital N"],
 ]


### PR DESCRIPTION
Reverts a part of https://github.com/dnglab/dnglab/commit/9dd28218375ae68ae5d5e44ae711bf0ce10d9754

Turns out there was at some point a firmware instance outputting this particular "Canon EOS 350D Digital" model string.

Apologies for the overhead.