### PR TITLE
Add support for Panasonic Lumix DC-GF9

### DIFF
--- a/rawler/data/cameras/panasonic/gx800.toml
+++ b/rawler/data/cameras/panasonic/gx800.toml
@@ -5,6 +5,7 @@ clean_model = "DC-GX800"
 
 model_aliases = [
   ["DC-GX850", "DC-GX850"],
+  ["DC-GF9", "DC-GF9"],
 ]
 
 #blackpoint = 143


### PR DESCRIPTION
Partially Solves #716. This only adds 4:3 mode from GX-800 to GF9 and no other aspect ratios.

Before
```
./target/release/dnglab convert ../best/PANASONIC_DC-GF9_ISO100_4-3_1.RW2 test.dng -d info
[ERROR ][dnglab_lib::jobs::raw2dng] Unsupported file: "PANASONIC_DC-GF9_ISO100_4-3_1.RW2"
Error: Unknown camera, model 'DC-GF9', make: 'Panasonic', mode: '4:3'
Please see https://github.com/dnglab/dnglab/blob/main/CONTRIBUTE_SAMPLES.md how to contribute samples to get this camera supported. (bin/dnglab/dnglab-lib/src/jobs/raw2dng.rs:104)
Converted 0/1 files, 1 failed:
   /Users/amtux/dev/test/best/PANASONIC_DC-GF9_ISO100_4-3_1.RW2
Total time: 0.03s
Error: Unsupported file: Error: Unknown camera, model 'DC-GF9', make: 'Panasonic', mode: '4:3'
```
After
```
./target/release/dnglab convert ../best/PANASONIC_DC-GF9_ISO100_4-3_1.RW2 test.dng -d info
[INFO  ][rawler::dng::convert] DNG conversion: 'PANASONIC_DC-GF9_ISO100_4-3_1.RW2', make: Panasonic, model: DC-GF9, raw-image-count: 1 (rawler/src/dng/convert.rs:116)
Writing DNG output file: test.dng
Converted 1/1 files
Total time: 0.17s
```

I tried to run `./target/release/dnglab cameras --md > SUPPORTED_CAMERAS.md` to add this new camera but there is a lot of other changes to that file so I left it out in this PR.

