### PR TITLE
Add lossless JPEG XL as compression option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +183,27 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "archmage"
+version = "0.9.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6248da30f2b6de70645c7af5b3658cf7d6dde8557a542efab62d21be13567d"
+dependencies = [
+ "archmage-macros",
+ "safe_unaligned_simd",
+]
+
+[[package]]
+name = "archmage-macros"
+version = "0.9.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0990742e24ab2b89d1b3623113cc474903d84151bef52e8b46d1ced2770c9ebb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -304,9 +334,23 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -504,10 +548,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -516,6 +561,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex 1.11.1",
@@ -527,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -626,6 +672,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "enough"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e1bd41ecce82c300d0c84fa35b080fa6db50a5398b18f1abf0357bb067549e"
 
 [[package]]
 name = "enumn"
@@ -730,6 +782,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "ftp"
@@ -909,6 +967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -1146,6 +1213,32 @@ dependencies = [
  "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
+]
+
+[[package]]
+name = "jxl-encoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2883a4596ba0212a4f005c29f55cc7d4e91603cc6574a91fe67338091849ac"
+dependencies = [
+ "archmage",
+ "bytemuck",
+ "enough",
+ "hashbrown 0.16.1",
+ "jxl-encoder-simd",
+ "once_cell",
+ "thiserror 2.0.12",
+ "whereat",
+]
+
+[[package]]
+name = "jxl-encoder-simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88c8baa7c73e9a4f7fdd58b9d996f2fef793416b4ea099f16adbe9b454e39f6"
+dependencies = [
+ "archmage",
+ "magetypes",
 ]
 
 [[package]]
@@ -1389,6 +1482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "magetypes"
+version = "0.9.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98970401ec6a338f1762c7986866ead4ab2257747cb0c247c29c0f0c3718b78e"
+dependencies = [
+ "archmage",
 ]
 
 [[package]]
@@ -1645,6 +1747,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1923,6 +2035,7 @@ dependencies = [
  "hex",
  "image",
  "itertools 0.14.0",
+ "jxl-encoder",
  "jxl-oxide",
  "lazy_static 1.5.0",
  "libflate",
@@ -2064,6 +2177,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_unaligned_simd"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c874fb993656d484725d58fbfddb39dfcf98ebcadc1a1d09568aa6b39bafba"
 
 [[package]]
 name = "same-file"
@@ -2589,6 +2708,12 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "whereat"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab90f361db038ba3135da12c938c328fb43a012992101879e3d6ebccb4d7eba8"
 
 [[package]]
 name = "winapi"

--- a/bin/dnglab/completions/_dnglab
+++ b/bin/dnglab/completions/_dnglab
@@ -151,7 +151,7 @@ _arguments "${_arguments_options[@]}" : \
 '-i+[Input files (raw, preview, exif, ...), index for map starts with 0]:INPUT:_files' \
 '--input=[Input files (raw, preview, exif, ...), index for map starts with 0]:INPUT:_files' \
 '--map=[Input usage map]:map:_default' \
-'--dng-backward-version=[DNG specification version]:version:(1.0 1.1 1.2 1.3 1.4 1.5 1.6)' \
+'--dng-backward-version=[DNG specification version]:version:(1.0 1.1 1.2 1.3 1.4 1.5 1.6 1.7)' \
 '--colorimetric-reference=[Reference for XYZ values]:reference:(scene output)' \
 '--unique-camera-model=[Unique camera model]:id:_default' \
 '--artist=[Set the Artist tag]:artist:_default' \

--- a/bin/dnglab/completions/_dnglab
+++ b/bin/dnglab/completions/_dnglab
@@ -76,8 +76,8 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (convert)
 _arguments "${_arguments_options[@]}" : \
-'-c+[Compression for raw image]:compression:(lossless uncompressed)' \
-'--compression=[Compression for raw image]:compression:(lossless uncompressed)' \
+'-c+[Compression for raw image]:compression:(lossless uncompressed jpegxl)' \
+'--compression=[Compression for raw image]:compression:(lossless uncompressed jpegxl)' \
 '--ljpeg92-predictor=[LJPEG-92 predictor]:predictor:_default' \
 '--dng-preview=[DNG include preview image]:preview:(true false)' \
 '--dng-thumbnail=[DNG include thumbnail image]:thumbnail:(true false)' \
@@ -101,8 +101,8 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (ftpserver)
 _arguments "${_arguments_options[@]}" : \
-'-c+[Compression for raw image]:compression:(lossless uncompressed)' \
-'--compression=[Compression for raw image]:compression:(lossless uncompressed)' \
+'-c+[Compression for raw image]:compression:(lossless uncompressed jpegxl)' \
+'--compression=[Compression for raw image]:compression:(lossless uncompressed jpegxl)' \
 '--ljpeg92-predictor=[LJPEG-92 predictor]:predictor:_default' \
 '--dng-preview=[DNG include preview image]:preview:(true false)' \
 '--dng-thumbnail=[DNG include thumbnail image]:thumbnail:(true false)' \

--- a/bin/dnglab/completions/dnglab.bash
+++ b/bin/dnglab/completions/dnglab.bash
@@ -532,7 +532,7 @@ _dnglab() {
                     return 0
                     ;;
                 --dng-backward-version)
-                    COMPREPLY=($(compgen -W "1.0 1.1 1.2 1.3 1.4 1.5 1.6" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "1.0 1.1 1.2 1.3 1.4 1.5 1.6 1.7" -- "${cur}"))
                     return 0
                     ;;
                 --colorimetric-reference)

--- a/bin/dnglab/completions/dnglab.bash
+++ b/bin/dnglab/completions/dnglab.bash
@@ -156,11 +156,11 @@ _dnglab() {
             fi
             case "${prev}" in
                 --compression)
-                    COMPREPLY=($(compgen -W "lossless uncompressed" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "lossless uncompressed jpegxl" -- "${cur}"))
                     return 0
                     ;;
                 -c)
-                    COMPREPLY=($(compgen -W "lossless uncompressed" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "lossless uncompressed jpegxl" -- "${cur}"))
                     return 0
                     ;;
                 --ljpeg92-predictor)
@@ -240,11 +240,11 @@ _dnglab() {
             fi
             case "${prev}" in
                 --compression)
-                    COMPREPLY=($(compgen -W "lossless uncompressed" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "lossless uncompressed jpegxl" -- "${cur}"))
                     return 0
                     ;;
                 -c)
-                    COMPREPLY=($(compgen -W "lossless uncompressed" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "lossless uncompressed jpegxl" -- "${cur}"))
                     return 0
                     ;;
                 --ljpeg92-predictor)

--- a/bin/dnglab/completions/dnglab.fish
+++ b/bin/dnglab/completions/dnglab.fish
@@ -80,7 +80,8 @@ complete -c dnglab -n "__fish_dnglab_using_subcommand process-raw" -s r -l recur
 complete -c dnglab -n "__fish_dnglab_using_subcommand process-raw" -s v -d 'Print status for every file'
 complete -c dnglab -n "__fish_dnglab_using_subcommand process-raw" -s h -l help -d 'Print help'
 complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -s c -l compression -d 'Compression for raw image' -r -f -a "lossless\t''
-uncompressed\t''"
+uncompressed\t''
+jpegxl\t''"
 complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -l ljpeg92-predictor -d 'LJPEG-92 predictor' -r
 complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -l dng-preview -d 'DNG include preview image' -r -f -a "true\t''
 false\t''"
@@ -105,7 +106,8 @@ complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -s r -l recursive
 complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -s v -d 'Print status for every file'
 complete -c dnglab -n "__fish_dnglab_using_subcommand convert" -s h -l help -d 'Print help'
 complete -c dnglab -n "__fish_dnglab_using_subcommand ftpserver" -s c -l compression -d 'Compression for raw image' -r -f -a "lossless\t''
-uncompressed\t''"
+uncompressed\t''
+jpegxl\t''"
 complete -c dnglab -n "__fish_dnglab_using_subcommand ftpserver" -l ljpeg92-predictor -d 'LJPEG-92 predictor' -r
 complete -c dnglab -n "__fish_dnglab_using_subcommand ftpserver" -l dng-preview -d 'DNG include preview image' -r -f -a "true\t''
 false\t''"

--- a/bin/dnglab/completions/dnglab.fish
+++ b/bin/dnglab/completions/dnglab.fish
@@ -159,7 +159,8 @@ complete -c dnglab -n "__fish_dnglab_using_subcommand makedng" -l dng-backward-v
 1.3\t''
 1.4\t''
 1.5\t''
-1.6\t''"
+1.6\t''
+1.7\t''"
 complete -c dnglab -n "__fish_dnglab_using_subcommand makedng" -l colorimetric-reference -d 'Reference for XYZ values' -r -f -a "scene\t''
 output\t''"
 complete -c dnglab -n "__fish_dnglab_using_subcommand makedng" -l unique-camera-model -d 'Unique camera model' -r

--- a/bin/dnglab/dnglab-lib/src/makedng.rs
+++ b/bin/dnglab/dnglab-lib/src/makedng.rs
@@ -695,7 +695,7 @@ impl DngVersion {
 
 impl clap::ValueEnum for DngVersion {
   fn value_variants<'a>() -> &'a [Self] {
-    &[Self::V1_0, Self::V1_1, Self::V1_2, Self::V1_3, Self::V1_4, Self::V1_5, Self::V1_6]
+    &[Self::V1_0, Self::V1_1, Self::V1_2, Self::V1_3, Self::V1_4, Self::V1_5, Self::V1_6, Self::V1_7]
   }
 
   fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
@@ -707,6 +707,7 @@ impl clap::ValueEnum for DngVersion {
       Self::V1_4 => clap::builder::PossibleValue::new("1.4"),
       Self::V1_5 => clap::builder::PossibleValue::new("1.5"),
       Self::V1_6 => clap::builder::PossibleValue::new("1.6"),
+      Self::V1_7 => clap::builder::PossibleValue::new("1.7"),
     })
   }
 }

--- a/bin/dnglab/dnglab-lib/src/makedng.rs
+++ b/bin/dnglab/dnglab-lib/src/makedng.rs
@@ -675,6 +675,7 @@ pub enum DngVersion {
   V1_4,
   V1_5,
   V1_6,
+  V1_7,
 }
 
 impl DngVersion {
@@ -687,6 +688,7 @@ impl DngVersion {
       DngVersion::V1_4 => dng::DNG_VERSION_V1_4,
       DngVersion::V1_5 => dng::DNG_VERSION_V1_5,
       DngVersion::V1_6 => dng::DNG_VERSION_V1_6,
+      DngVersion::V1_7 => dng::DNG_VERSION_V1_7,
     }
   }
 }

--- a/bin/dnglab/manpages/dnglab-convert.1
+++ b/bin/dnglab/manpages/dnglab-convert.1
@@ -14,7 +14,7 @@ Compression for raw image
 .br
 
 .br
-[\fIpossible values: \fRlossless, uncompressed]
+[\fIpossible values: \fRlossless, uncompressed, jpegxl]
 .TP
 \fB\-\-ljpeg92\-predictor\fR=\fIpredictor\fR [default: 1]
 LJPEG\-92 predictor

--- a/bin/dnglab/manpages/dnglab-ftpserver.1
+++ b/bin/dnglab/manpages/dnglab-ftpserver.1
@@ -14,7 +14,7 @@ Compression for raw image
 .br
 
 .br
-[\fIpossible values: \fRlossless, uncompressed]
+[\fIpossible values: \fRlossless, uncompressed, jpegxl]
 .TP
 \fB\-\-ljpeg92\-predictor\fR=\fIpredictor\fR [default: 1]
 LJPEG\-92 predictor

--- a/bin/dnglab/manpages/dnglab-makedng.1
+++ b/bin/dnglab/manpages/dnglab-makedng.1
@@ -26,7 +26,7 @@ DNG specification version
 .br
 
 .br
-[\fIpossible values: \fR1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6]
+[\fIpossible values: \fR1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
 .TP
 \fB\-\-colorimetric\-reference\fR=\fIreference\fR [default: scene]
 Reference for XYZ values

--- a/bin/dnglab/manpages/dnglab-process-raw.1
+++ b/bin/dnglab/manpages/dnglab-process-raw.1
@@ -1,0 +1,44 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH dnglab-process-raw 1  "dnglab-process-raw " 
+.SH NAME
+dnglab\-process\-raw
+.SH SYNOPSIS
+\fBdnglab\-process\-raw\fR [\fB\-\-artist\fR] [\fB\-\-keep\-mtime\fR] [\fB\-\-image\-index\fR] [\fB\-\-crop\fR] [\fB\-f\fR|\fB\-\-override\fR] [\fB\-r\fR|\fB\-\-recursive\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIINPUT\fR> <\fIOUTPUT\fR> 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-artist\fR=\fIartist\fR
+Set the artist tag
+.TP
+\fB\-\-keep\-mtime\fR=\fIkeepmtime\fR [default: false]
+Keep mtime, read from EXIF with fallback to original file mtime
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.TP
+\fB\-\-image\-index\fR=\fIindex\fR [default: 0]
+Select a specific image index (or \*(Aqall\*(Aq) if file is a image container
+.TP
+\fB\-\-crop\fR=\fIcrop\fR [default: best]
+DNG default crop
+.br
+
+.br
+[\fIpossible values: \fRbest, activearea, none]
+.TP
+\fB\-f\fR, \fB\-\-override\fR
+Override existing files
+.TP
+\fB\-r\fR, \fB\-\-recursive\fR
+Process input directory recursive
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIINPUT\fR>
+Input file or directory
+.TP
+<\fIOUTPUT\fR>
+Output file or existing directory

--- a/rawler/Cargo.toml
+++ b/rawler/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4"
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
 itertools = "0.14"
 lazy_static = "1"
+jxl-encoder = { version = "0.3.1", default-features = false, features = ["std"] }
 jxl-oxide = "0.12.2"
 libflate = "2.0"
 log = "0.4"

--- a/rawler/src/dng/mod.rs
+++ b/rawler/src/dng/mod.rs
@@ -41,13 +41,14 @@ pub fn rect_to_dng_area(area: &Rect) -> [u16; 4] {
 #[cfg(feature = "clap")]
 impl clap::ValueEnum for DngCompression {
   fn value_variants<'a>() -> &'a [Self] {
-    &[Self::Lossless, Self::Uncompressed]
+    &[Self::Lossless, Self::Uncompressed, Self::JpegXL]
   }
 
   fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
     Some(match self {
       Self::Uncompressed => clap::builder::PossibleValue::new("uncompressed"),
       Self::Lossless => clap::builder::PossibleValue::new("lossless"),
+      Self::JpegXL => clap::builder::PossibleValue::new("jpegxl"),
     })
   }
 }
@@ -110,5 +111,7 @@ pub enum DngCompression {
   Uncompressed,
   /// Lossless JPEG-92 compression
   Lossless,
+  /// Lossless JPEG-XL compression
+  JpegXL,
   // Lossy
 }

--- a/rawler/src/dng/mod.rs
+++ b/rawler/src/dng/mod.rs
@@ -14,6 +14,7 @@ pub const DNG_VERSION_V1_3: [u8; 4] = [1, 3, 0, 0];
 pub const DNG_VERSION_V1_4: [u8; 4] = [1, 4, 0, 0];
 pub const DNG_VERSION_V1_5: [u8; 4] = [1, 5, 0, 0];
 pub const DNG_VERSION_V1_6: [u8; 4] = [1, 6, 0, 0];
+pub const DNG_VERSION_V1_7: [u8; 4] = [1, 7, 0, 0];
 
 /// Convert internal crop rectangle to DNG active area
 ///

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -32,7 +32,7 @@ use crate::{
   tags::{DngTag, TiffCommonTag},
 };
 
-use super::{CropMode, DNG_VERSION_V1_6, DngCompression, DngPhotometricConversion, original::OriginalCompressed};
+use super::{CropMode, DNG_VERSION_V1_7, DngCompression, DngPhotometricConversion, original::OriginalCompressed};
 
 pub type DngError = TiffError;
 
@@ -378,7 +378,7 @@ where
     let mut root_ifd = DirectoryWriter::new();
     let mut exif_ifd = DirectoryWriter::new();
     root_ifd.add_tag(DngTag::DNGBackwardVersion, backward_version);
-    root_ifd.add_tag(DngTag::DNGVersion, DNG_VERSION_V1_6);
+    root_ifd.add_tag(DngTag::DNGVersion, DNG_VERSION_V1_7);
     // Add EXIF version 0220
     exif_ifd.add_tag_undefined(ExifTag::ExifVersion, vec![48, 50, 50, 48]);
 

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -308,7 +308,7 @@ where
       }
       DngCompression::JpegXL => {
         if self.writer.backward_version < DNG_VERSION_V1_7 {
-          return Err(DngError::General("JPEG-XL requires DNG 1.7.0.0 or later".into()));
+          self.writer.root_ifd_mut().add_tag(DngTag::DNGBackwardVersion, DNG_VERSION_V1_7);
         }
         self.ifd_mut().add_tag(TiffCommonTag::Compression, CompressionMethod::JPEGXL);
         dng_put_raw_jpegxl(self, &rawimage)?;
@@ -674,9 +674,7 @@ where
           assert_eq!(rawimage.cpp, 1);
           (tile_w, tile_h, 1)
         }
-        RawPhotometricInterpretation::LinearRaw => {
-          (tile_w, tile_h, rawimage.cpp)
-        }
+        RawPhotometricInterpretation::LinearRaw => (tile_w, tile_h, rawimage.cpp),
       };
 
       debug!("JPEG-XL compression: bit depth: {}", rawimage.bps);
@@ -686,9 +684,7 @@ where
       let tiles_compr: Vec<Vec<u8>> = tiled_data
         .par_iter()
         .map(|tile| {
-          let bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(tile.as_ptr() as *const u8, tile.len() * size_of::<u16>())
-          };
+          let bytes: &[u8] = unsafe { std::slice::from_raw_parts(tile.as_ptr() as *const u8, tile.len() * size_of::<u16>()) };
           let layout = if components == 1 { PixelLayout::Gray16 } else { PixelLayout::Rgb16 };
           config
             .encode(bytes, j_width as u32, j_height as u32, layout)

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use image::{DynamicImage, codecs::jpeg::JpegEncoder, imageops::FilterType};
+use jxl_encoder::{LosslessConfig, PixelLayout};
 use log::debug;
 use rayon::prelude::*;
 
@@ -144,7 +145,7 @@ where
   }
 
   fn write_rawimage(&mut self, mut rawimage: Cow<RawImage>, cropmode: CropMode, compression: DngCompression, predictor: u8) -> Result<()> {
-    if compression == DngCompression::Lossless && matches!(rawimage.data, RawImageData::Float(_)) {
+    if (compression == DngCompression::Lossless || compression == DngCompression::JpegXL) && matches!(rawimage.data, RawImageData::Float(_)) {
       // Lossless (LJPEG92) can only be used for 16 bit integer data.
       // If we have floats, convert them.
       rawimage.to_mut().data.force_integer();
@@ -303,6 +304,10 @@ where
       DngCompression::Lossless => {
         self.ifd_mut().add_tag(TiffCommonTag::Compression, CompressionMethod::ModernJPEG);
         dng_put_raw_ljpeg(self, &rawimage, predictor)?;
+      }
+      DngCompression::JpegXL => {
+        self.ifd_mut().add_tag(TiffCommonTag::Compression, CompressionMethod::JPEGXL);
+        dng_put_raw_jpegxl(self, &rawimage)?;
       }
     }
 
@@ -623,6 +628,79 @@ where
   let mut tile_sizes: Vec<u32> = Vec::new();
 
   for tile in lj92_data.iter() {
+    let offs = subframe.writer.dng.write_data(tile)?;
+    tile_offsets.push(offs);
+    tile_sizes.push((tile.len() * size_of::<u8>()) as u32);
+  }
+
+  subframe
+    .ifd_mut()
+    .add_tag(TiffCommonTag::BitsPerSample, &vec![rawimage.bps as u16; rawimage.cpp]);
+  subframe.ifd_mut().add_tag(TiffCommonTag::SampleFormat, &vec![1_u16; rawimage.cpp]);
+  subframe.ifd_mut().add_tag(TiffCommonTag::TileOffsets, &tile_offsets);
+  subframe.ifd_mut().add_tag(TiffCommonTag::TileByteCounts, &tile_sizes);
+  subframe.ifd_mut().add_tag(TiffCommonTag::TileWidth, tile_w as u16);
+  subframe.ifd_mut().add_tag(TiffCommonTag::TileLength, tile_h as u16);
+
+  Ok(())
+}
+
+/// Compress RAW image with JPEG-XL lossless
+///
+/// Data is split into multiple tiles, each tile is compressed seperately
+/// using the JPEG-XL modular mode (lossless).
+fn dng_put_raw_jpegxl<W>(subframe: &mut SubFrameWriter<W>, rawimage: &RawImage) -> Result<()>
+where
+  W: Seek + Write,
+{
+  let tile_w = 256 & !0b111; // ensure div 16
+  let tile_h = 256 & !0b111;
+
+  let jxl_data = match rawimage.data {
+    RawImageData::Integer(ref data) => {
+      let tiled_data: Vec<Vec<u16>> = ImageTiler::new(data, rawimage.width, rawimage.height, rawimage.cpp, tile_w, tile_h).collect();
+
+      let (j_width, j_height, components) = match &rawimage.photometric {
+        RawPhotometricInterpretation::BlackIsZero => {
+          assert_eq!(rawimage.cpp, 1);
+          (tile_w, tile_h, 1)
+        }
+        RawPhotometricInterpretation::Cfa(_config) => {
+          assert_eq!(rawimage.cpp, 1);
+          (tile_w, tile_h, 1)
+        }
+        RawPhotometricInterpretation::LinearRaw => {
+          (tile_w, tile_h, rawimage.cpp)
+        }
+      };
+
+      debug!("JPEG-XL compression: bit depth: {}", rawimage.bps);
+
+      let config = LosslessConfig::new();
+
+      let tiles_compr: Vec<Vec<u8>> = tiled_data
+        .par_iter()
+        .map(|tile| {
+          let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(tile.as_ptr() as *const u8, tile.len() * size_of::<u16>())
+          };
+          let layout = if components == 1 { PixelLayout::Gray16 } else { PixelLayout::Rgb16 };
+          config
+            .encode(bytes, j_width as u32, j_height as u32, layout)
+            .map_err(|e| DngError::General(format!("JPEG-XL encoding failed: {}", e)))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      tiles_compr
+    }
+    RawImageData::Float(ref _data) => {
+      panic!("invalid format");
+    }
+  };
+
+  let mut tile_offsets: Vec<u32> = Vec::new();
+  let mut tile_sizes: Vec<u32> = Vec::new();
+
+  for tile in jxl_data.iter() {
     let offs = subframe.writer.dng.write_data(tile)?;
     tile_offsets.push(offs);
     tile_sizes.push((tile.len() * size_of::<u8>()) as u32);

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -43,6 +43,7 @@ where
   B: Write + Seek,
 {
   pub dng: TiffWriter<B>,
+  backward_version: [u8; 4],
   root_ifd: DirectoryWriter,
   //raw_ifd: DirectoryWriter,
   //preview_ifd: DirectoryWriter,
@@ -306,6 +307,9 @@ where
         dng_put_raw_ljpeg(self, &rawimage, predictor)?;
       }
       DngCompression::JpegXL => {
+        if self.writer.backward_version < DNG_VERSION_V1_7 {
+          return Err(DngError::General("JPEG-XL requires DNG 1.7.0.0 or later".into()));
+        }
         self.ifd_mut().add_tag(TiffCommonTag::Compression, CompressionMethod::JPEGXL);
         dng_put_raw_jpegxl(self, &rawimage)?;
       }
@@ -384,6 +388,7 @@ where
 
     Ok(Self {
       dng,
+      backward_version,
       root_ifd,
       exif_ifd,
       subs: Vec::new(),


### PR DESCRIPTION
Hi, thanks for this awesome project!

So DNG has added JPEG-XL, and dnglab already supports it (https://github.com/dnglab/dnglab/pull/562)
Though [JPEG-XL encoding](https://github.com/dnglab/dnglab/issues/528) hasn't been added yet.

After some time googling, it seems there's rust implementation of libjxl already (`jxl-encoder`)

I did some tests, the output is a bit smaller (21MB vs 25MB, so 16% smaller), and Adobe Photoshop/Lightroom seems to open/process it without any problems.

``` sh
25M default.DNG
24M DSC06932.ARW
21M jpegxl.dng
```

Right now it takes about 6 seconds to convert a 24MP on a 5800x3d.

I think more testing are needed here, creating a draft PR in case anyone want to work on this or give it a try.

Disclaimer: the changes are mostly done by an AI.
I have never done any works in media encoding, so I was mostly educating myself using online resources, and just reading through the pdf.