### PR TITLE
Fix panic on invalid Fuji code value, return 0 instead in fuji_decompressor.rs:919

### DIFF
--- a/rawler/src/decoders/raf/fuji_decompressor.rs
+++ b/rawler/src/decoders/raf/fuji_decompressor.rs
@@ -916,7 +916,7 @@ fn read_code(pump: &mut BitPumpMSB, params: &Params, gradient: &mut Gradient, q_
   };
   // Validate code
   if code < 0 || code >= q_table.total_values as i32 {
-    panic!("Invalid code: {}", code);
+    return 0; // treat out-of-range codes as zero rather than crashing
   }
   // Adjust code
   if (code & 1) != 0 {


### PR DESCRIPTION
Alternatively it could return Option<>, but this may require a lot of more changes