### PR TITLE
Make decoders panic-free on malformed input (fuzz-hardening)

### DIFF
--- a/rawler/src/bits.rs
+++ b/rawler/src/bits.rs
@@ -80,45 +80,52 @@ impl Endian {
     matches!(*self, Self::Little)
   }
 
+  // EOF-safe: see the note on the free `LEu16`/`BEu16`/… readers below. An
+  // out-of-range `offset` (from an untrusted file) returns 0 instead of
+  // panicking; well-formed input is unaffected.
   #[inline]
   pub fn read_u8(&self, buf: &[u8], offset: usize) -> u8 {
-    buf[offset]
+    buf.get(offset).copied().unwrap_or(0)
   }
 
   #[inline]
   pub fn read_i8(&self, buf: &[u8], offset: usize) -> i8 {
-    buf[offset] as i8
+    buf.get(offset).map_or(0, |&b| b as i8)
   }
 
   #[inline]
   pub fn read_u16(&self, buf: &[u8], offset: usize) -> u16 {
-    match *self {
-      Self::Big => BigEndian::read_u16(&buf[offset..]),
-      Self::Little => LittleEndian::read_u16(&buf[offset..]),
+    match buf.get(offset..offset.saturating_add(2)) {
+      Some(b) if self.little() => LittleEndian::read_u16(b),
+      Some(b) => BigEndian::read_u16(b),
+      None => 0,
     }
   }
 
   #[inline]
   pub fn read_i16(&self, buf: &[u8], offset: usize) -> i16 {
-    match *self {
-      Self::Big => BigEndian::read_i16(&buf[offset..]),
-      Self::Little => LittleEndian::read_i16(&buf[offset..]),
+    match buf.get(offset..offset.saturating_add(2)) {
+      Some(b) if self.little() => LittleEndian::read_i16(b),
+      Some(b) => BigEndian::read_i16(b),
+      None => 0,
     }
   }
 
   #[inline]
   pub fn read_u32(&self, buf: &[u8], offset: usize) -> u32 {
-    match *self {
-      Self::Big => BigEndian::read_u32(&buf[offset..]),
-      Self::Little => LittleEndian::read_u32(&buf[offset..]),
+    match buf.get(offset..offset.saturating_add(4)) {
+      Some(b) if self.little() => LittleEndian::read_u32(b),
+      Some(b) => BigEndian::read_u32(b),
+      None => 0,
     }
   }
 
   #[inline]
   pub fn read_i32(&self, buf: &[u8], offset: usize) -> i32 {
-    match *self {
-      Self::Big => BigEndian::read_i32(&buf[offset..]),
-      Self::Little => LittleEndian::read_i32(&buf[offset..]),
+    match buf.get(offset..offset.saturating_add(4)) {
+      Some(b) if self.little() => LittleEndian::read_i32(b),
+      Some(b) => BigEndian::read_i32(b),
+      None => 0,
     }
   }
 
@@ -131,80 +138,94 @@ impl Endian {
   }
 }
 
+// NOTE: these byte readers take a caller-computed `pos` that, for camera raw
+// formats, is frequently derived from offsets/lengths stored in the (untrusted)
+// file. A malformed file can make `pos` point past the end of `buf`, which with
+// a raw `&buf[pos..pos + N]` slice panics ("range … out of range"). To keep the
+// decoders panic-free on hostile input — matching the dcraw lineage and rawler's
+// own `PaddedBuf` over-read convention — an out-of-range read returns 0 (a wild
+// offset can't be served by zero-padding the buffer). On well-formed input every
+// read is in bounds, so the result is bit-identical to a direct slice read; the
+// `0` branch is only ever taken on truncated/corrupt input.
+
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEi32(buf: &[u8], pos: usize) -> i32 {
-  BigEndian::read_i32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0, |b| BigEndian::read_i32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEi32(buf: &[u8], pos: usize) -> i32 {
-  LittleEndian::read_i32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0, |b| LittleEndian::read_i32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEu32(buf: &[u8], pos: usize) -> u32 {
-  BigEndian::read_u32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0, |b| BigEndian::read_u32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEu32(buf: &[u8], pos: usize) -> u32 {
-  LittleEndian::read_u32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0, |b| LittleEndian::read_u32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEf32(buf: &[u8], pos: usize) -> f32 {
-  LittleEndian::read_f32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0.0, |b| LittleEndian::read_f32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEf24(buf: &[u8], pos: usize) -> f32 {
-  let fp24: u32 = u32::from_le_bytes([buf[pos + 0], buf[pos + 1], buf[pos + 2], 0]);
+  let b = buf.get(pos..pos.saturating_add(3)).unwrap_or(&[0, 0, 0]);
+  let fp24: u32 = u32::from_le_bytes([b[0], b[1], b[2], 0]);
   f32::from_bits(extend_binary_floating_point::<Binary24, Binary32>(fp24))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEf24(buf: &[u8], pos: usize) -> f32 {
-  let fp24: u32 = u32::from_be_bytes([0, buf[pos + 0], buf[pos + 1], buf[pos + 2]]);
+  let b = buf.get(pos..pos.saturating_add(3)).unwrap_or(&[0, 0, 0]);
+  let fp24: u32 = u32::from_be_bytes([0, b[0], b[1], b[2]]);
   f32::from_bits(extend_binary_floating_point::<Binary24, Binary32>(fp24))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEf16(buf: &[u8], pos: usize) -> f32 {
-  let fp16: u16 = u16::from_le_bytes([buf[pos + 0], buf[pos + 1]]);
+  let b = buf.get(pos..pos.saturating_add(2)).unwrap_or(&[0, 0]);
+  let fp16: u16 = u16::from_le_bytes([b[0], b[1]]);
   f32::from_bits(extend_binary_floating_point::<Binary16, Binary32>(fp16 as u32))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEf16(buf: &[u8], pos: usize) -> f32 {
-  let fp16: u16 = u16::from_be_bytes([buf[pos + 0], buf[pos + 1]]);
+  let b = buf.get(pos..pos.saturating_add(2)).unwrap_or(&[0, 0]);
+  let fp16: u16 = u16::from_be_bytes([b[0], b[1]]);
   f32::from_bits(extend_binary_floating_point::<Binary16, Binary32>(fp16 as u32))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEf32(buf: &[u8], pos: usize) -> f32 {
-  BigEndian::read_f32(&buf[pos..pos + 4])
+  buf.get(pos..pos.saturating_add(4)).map_or(0.0, |b| BigEndian::read_f32(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn BEu16(buf: &[u8], pos: usize) -> u16 {
-  BigEndian::read_u16(&buf[pos..pos + 2])
+  buf.get(pos..pos.saturating_add(2)).map_or(0, |b| BigEndian::read_u16(b))
 }
 
 #[allow(non_snake_case)]
 #[inline]
 pub fn LEu16(buf: &[u8], pos: usize) -> u16 {
-  LittleEndian::read_u16(&buf[pos..pos + 2])
+  buf.get(pos..pos.saturating_add(2)).map_or(0, |b| LittleEndian::read_u16(b))
 }
 
 #[derive(Debug, Clone)]
@@ -219,8 +240,22 @@ impl LookupTable {
       let center = table[i];
       let lower = if i > 0 { table[i - 1] } else { center };
       let upper = if i < (table.len() - 1) { table[i + 1] } else { center };
-      let base = if center == 0 { 0 } else { center - ((upper - lower + 2) / 4) };
-      let delta = upper - lower;
+      // A real lookup table is a monotonic tone curve, so `upper >= lower` and
+      // `center >= (upper - lower + 2) / 4`; these subtractions never underflow
+      // on well-formed input. An attacker-supplied (e.g. unwrapped-decoder) table
+      // can be non-monotonic, underflowing the `u16` subtraction and panicking
+      // under overflow checks (in plain release it would silently wrap, which is
+      // worse). `saturating_sub` yields the identical value whenever the curve is
+      // monotonic and clamps to 0 otherwise, so valid decodes are unchanged.
+      let delta = upper.saturating_sub(lower);
+      // Compute `(delta + 2) / 4` in u32 to avoid overflowing `u16` when delta is
+      // large (only possible for a non-monotonic, i.e. malformed, table). For a
+      // real curve delta is small so the value is identical to the u16 form.
+      let base = if center == 0 {
+        0
+      } else {
+        center.saturating_sub((((delta as u32) + 2) / 4) as u16)
+      };
       tbl[i] = (center, base, delta);
     }
     LookupTable { table: tbl }

--- a/rawler/src/decoders/arw.rs
+++ b/rawler/src/decoders/arw.rs
@@ -448,7 +448,11 @@ impl<'a> ArwDecoder<'a> {
       height,
       dummy,
       &(|out: &mut [u16], row| {
-        let mut pump = BitPumpLSB::new(&buf[(row * width)..]);
+        // `row * width` indexes into the file-derived `buf`; a short buffer makes
+        // the per-row start exceed it. A valid ARW2 frame has a row at this
+        // offset, so the slice is unchanged; otherwise the bit pump reads zeros
+        // past EOF (it is itself exhaustion-safe).
+        let mut pump = BitPumpLSB::new(buf.get((row * width)..).unwrap_or(&[]));
 
         let mut random = pump.peek_bits(16);
         for out in out.chunks_exact_mut(32) {
@@ -456,7 +460,9 @@ impl<'a> ArwDecoder<'a> {
           for j in 0..2 {
             let max = pump.get_bits(11);
             let min = pump.get_bits(11);
-            let delta = max - min;
+            // A corrupt bitstream can yield min > max; `saturating_sub` matches
+            // the real (max >= min) value and avoids an underflow panic.
+            let delta = max.saturating_sub(min);
             // Calculate the size of the data shift needed by how large the delta is
             // A delta with 11 bits requires a shift of 4, 10 bits of 3, etc
             let delta_shift: u32 = cmp::max(0, (32 - (delta.leading_zeros() as i32)) - 7) as u32;

--- a/rawler/src/decoders/kdc.rs
+++ b/rawler/src/decoders/kdc.rs
@@ -194,7 +194,11 @@ impl<'a> KdcDecoder<'a> {
     for row in 0..height {
       let shift = row * mul[row & 3] + add[row & 3];
       for col in 0..width {
-        out[row * width + col] = src[row * width + ((col + shift) % 848)] as u16;
+        // `src` is indexed by a file-size-dependent position; a short/corrupt
+        // buffer makes this read out of range. For a valid DC120 frame the
+        // source is large enough that every read is in bounds, so the result is
+        // unchanged; a missing source byte reads as 0 instead of panicking.
+        out[row * width + col] = src.get(row * width + ((col + shift) % 848)).copied().unwrap_or(0) as u16;
       }
     }
     out

--- a/rawler/src/decoders/mrw.rs
+++ b/rawler/src/decoders/mrw.rs
@@ -147,7 +147,11 @@ impl<'a> MrwDecoder<'a> {
   fn new_mrw(file: &RawSource, rawloader: &'a RawLoader) -> Result<MrwDecoder<'a>> {
     let full = file.as_vec()?;
     let buf = &full;
-    let data_offset: usize = (BEu32(buf, 4) + 8) as usize;
+    // Widen before adding: `BEu32(..) + 8` as `u32 + u32` overflows when the
+    // file stores a near-u32::MAX length, panicking under overflow checks. The
+    // widened sum is identical for any real MRW data offset, so valid files are
+    // unchanged.
+    let data_offset: usize = BEu32(buf, 4) as usize + 8;
     let mut raw_height: usize = 0;
     let mut raw_width: usize = 0;
     let bits = 12;
@@ -166,7 +170,12 @@ impl<'a> MrwDecoder<'a> {
           // PRD
           raw_height = BEu16(buf, currpos + 16) as usize;
           raw_width = BEu16(buf, currpos + 18) as usize;
-          packed = buf[currpos + 24] == 12;
+          // `buf[currpos + 24]` indexed directly; the loop only guarantees
+          // `currpos + 20 < data_offset`, so on a corrupt/short file this can
+          // read past the end and panic. A missing byte is treated as 0 (not
+          // `12`, i.e. not packed) — for a valid PRD block the byte is present
+          // so the result is unchanged.
+          packed = buf.get(currpos + 24).copied().unwrap_or(0) == 12;
         }
         0x574247 => {
           // WBG
@@ -182,7 +191,11 @@ impl<'a> MrwDecoder<'a> {
         }
         _ => {}
       }
-      currpos += (len + 8) as usize;
+      // Widen before adding: `len + 8` as `u32 + u32` overflows when a block
+      // declares a near-u32::MAX length, panicking under overflow checks.
+      // Widening to usize matches the value for any real block length; the
+      // loop's `currpos + 20 < data_offset` guard still terminates the scan.
+      currpos += len as usize + 8;
     }
 
     let tiff_data = file.subview_until_eof(tiffpos as u64)?;

--- a/rawler/src/decoders/nef.rs
+++ b/rawler/src/decoders/nef.rs
@@ -719,7 +719,10 @@ impl<'a> NefDecoder<'a> {
       height,
       dummy,
       &(|out: &mut [u16], row| {
-        let inb = &src[row * width * 3..];
+        // `row * width * 3` indexes the file-derived source; a short buffer makes
+        // the per-row offset exceed it. A valid SNEF frame has each row present,
+        // so the slice is unchanged; otherwise this errors instead of panicking.
+        let inb = src.get(row * width * 3..).ok_or_else(|| format!("SNEF: row {} offset out of range", row))?;
         let mut random = BEu32(inb, 0);
         for (o, i) in out.chunks_exact_mut(6).zip(inb.chunks_exact(6)) {
           let g1: u16 = i[0] as u16;
@@ -738,17 +741,22 @@ impl<'a> NefDecoder<'a> {
           let g = snef_curve.dither(clampbits((y1 - 0.337633 * cb - 0.698001 * cr) as i32, 12), &mut random);
           let b = snef_curve.dither(clampbits((y1 + 1.732446 * cb) as i32, 12), &mut random);
           // invert the white balance
-          o[0] = clampbits((inv_wb_r * r as i32 + (1 << 9)) >> 10, 15);
+          // `inv_wb_*` is `(1024.0 / coeff) as i32`; for valid white-balance
+          // coefficients this is a small multiplier and `inv_wb * v` fits in
+          // i32. A crafted near-zero coefficient makes `inv_wb` saturate to
+          // i32::MAX, overflowing the i32 product. Compute in i64 (the result is
+          // clamped to 15 bits anyway), which is identical for valid input.
+          o[0] = clampbits(((inv_wb_r as i64 * r as i64 + (1 << 9)) >> 10) as i32, 15);
           o[1] = g;
-          o[2] = clampbits((inv_wb_b * b as i32 + (1 << 9)) >> 10, 15);
+          o[2] = clampbits(((inv_wb_b as i64 * b as i64 + (1 << 9)) >> 10) as i32, 15);
 
           let r = snef_curve.dither(clampbits((y2 + 1.370705 * cr) as i32, 12), &mut random);
           let g = snef_curve.dither(clampbits((y2 - 0.337633 * cb - 0.698001 * cr) as i32, 12), &mut random);
           let b = snef_curve.dither(clampbits((y2 + 1.732446 * cb) as i32, 12), &mut random);
-          // invert the white balance
-          o[3] = clampbits((inv_wb_r * r as i32 + (1 << 9)) >> 10, 15);
+          // invert the white balance (see above; computed in i64 to avoid overflow)
+          o[3] = clampbits(((inv_wb_r as i64 * r as i64 + (1 << 9)) >> 10) as i32, 15);
           o[4] = g;
-          o[5] = clampbits((inv_wb_b * b as i32 + (1 << 9)) >> 10, 15);
+          o[5] = clampbits(((inv_wb_b as i64 * b as i64 + (1 << 9)) >> 10) as i32, 15);
         }
         Ok(())
       }),

--- a/rawler/src/decoders/orf.rs
+++ b/rawler/src/decoders/orf.rs
@@ -283,7 +283,10 @@ impl<'a> OrfDecoder<'a> {
     let mut left: [i32; 2] = [0; 2];
     let mut nw: [i32; 2] = [0; 2];
     let skip = if bps == 14 { 8 } else { 7 };
-    let mut pump = BitPumpMSB::new(&buf[skip..]);
+    // A valid ORF strip is always larger than the 7/8-byte skip; a corrupt/short
+    // buffer is handled by reading an empty (zero-yielding, exhaustion-safe) bit
+    // stream rather than panicking on the slice.
+    let mut pump = BitPumpMSB::new(buf.get(skip..).unwrap_or(&[]));
 
     for row in 0..height {
       let mut acarry: [[i32; 3]; 2] = [[0; 3]; 2];
@@ -312,9 +315,17 @@ impl<'a> OrfDecoder<'a> {
             pump.consume_bits((high + 4) as u32);
           }
 
-          acarry[s][0] = ((high << nbits) | pump.get_ibits(nbits)) as i32;
-          let diff = (acarry[s][0] ^ sign) + acarry[s][1];
-          acarry[s][1] = (diff * 3 + acarry[s][1]) >> 5;
+          // These predictor calculations stay within pixel range for a valid
+          // ORF stream, so none of them overflow `i32` on well-formed input. A
+          // crafted stream can drive the accumulated values out of range; use
+          // wrapping arithmetic (matching the release build, which has no
+          // overflow checks) so such input wraps rather than panicking, leaving
+          // valid decodes bit-identical. The sign-only product is widened to
+          // `i64` so its comparison is correct even when the i32 product would
+          // have overflowed.
+          acarry[s][0] = (high.wrapping_shl(nbits)) | pump.get_ibits(nbits);
+          let diff = (acarry[s][0] ^ sign).wrapping_add(acarry[s][1]);
+          acarry[s][1] = (diff.wrapping_mul(3).wrapping_add(acarry[s][1])) >> 5;
           acarry[s][2] = if acarry[s][0] > 16 { 0 } else { acarry[s][2] + 1 };
 
           if row < 2 || col < 2 {
@@ -330,26 +341,26 @@ impl<'a> OrfDecoder<'a> {
               nw[s] = out[(row - 2) * width + (col + s)] as i32;
               nw[s]
             };
-            left[s] = pred + ((diff << 2) | low);
+            left[s] = pred.wrapping_add((diff.wrapping_shl(2)) | low);
             out[row * width + (col + s)] = left[s] as u16;
           } else {
             let up: i32 = out[(row - 2) * width + (col + s)] as i32;
-            let left_minus_nw: i32 = left[s] - nw[s];
-            let up_minus_nw: i32 = up - nw[s];
+            let left_minus_nw: i32 = left[s].wrapping_sub(nw[s]);
+            let up_minus_nw: i32 = up.wrapping_sub(nw[s]);
             // Check if sign is different, and one is not zero
-            let pred = if left_minus_nw * up_minus_nw < 0 {
-              if left_minus_nw.abs() > 32 || up_minus_nw.abs() > 32 {
-                left[s] + up_minus_nw
+            let pred = if (left_minus_nw as i64) * (up_minus_nw as i64) < 0 {
+              if left_minus_nw.unsigned_abs() > 32 || up_minus_nw.unsigned_abs() > 32 {
+                left[s].wrapping_add(up_minus_nw)
               } else {
-                (left[s] + up) >> 1
+                (left[s].wrapping_add(up)) >> 1
               }
-            } else if left_minus_nw.abs() > up_minus_nw.abs() {
+            } else if left_minus_nw.unsigned_abs() > up_minus_nw.unsigned_abs() {
               left[s]
             } else {
               up
             };
 
-            left[s] = pred + ((diff << 2) | low);
+            left[s] = pred.wrapping_add((diff.wrapping_shl(2)) | low);
             nw[s] = up;
             out[row * width + (col + s)] = left[s] as u16;
           }

--- a/rawler/src/decoders/pef.rs
+++ b/rawler/src/decoders/pef.rs
@@ -285,8 +285,15 @@ impl<'a> PefDecoder<'a> {
       // Calculate codes and store bitcounts
       let mut v2: [u32; 16] = [0; 16];
       for c in 0..depth {
-        v2[c] = v0[c] >> (12 - v1[c]);
-        htable.bits[v1[c] as usize] += 1;
+        // `v1[c]` is a Huffman code length from the (untrusted) makernote table.
+        // For a valid PEF it is 1..=12, so `12 - v1[c]` and `bits[v1[c]]` are in
+        // range and behave exactly as before. A crafted length > 12 would
+        // underflow the shift, and one > 16 would index past `bits[17]`; clamp
+        // the shift and skip an out-of-range bit count so such input can't panic.
+        v2[c] = v0[c] >> (12u32.saturating_sub(v1[c]));
+        if let Some(slot) = htable.bits.get_mut(v1[c] as usize) {
+          *slot += 1;
+        }
       }
 
       // Find smallest
@@ -312,7 +319,12 @@ impl<'a> PefDecoder<'a> {
         acc += htable.bits[i + 1] as usize;
       }
       for i in 0..acc {
-        htable.huffval[i] = pentax_tree[i + 16] as u32;
+        // Guard the fixed-table read: `acc` (14) can index one past the 13
+        // huffval entries stored at indices 16.. of `pentax_tree`. This legacy
+        // fallback only runs when no makernote Huffman table is present (never
+        // for a real PEF), so reading 0 for a missing entry can't affect valid
+        // decoding — it just avoids an out-of-bounds panic on crafted input.
+        htable.huffval[i] = pentax_tree.get(i + 16).copied().unwrap_or(0) as u32;
       }
     }
 
@@ -329,13 +341,25 @@ impl<'a> PefDecoder<'a> {
       pred_up2[row & 1] += htable.huff_decode(&mut pump)?;
       pred_left1 = pred_up1[row & 1];
       pred_left2 = pred_up2[row & 1];
-      out[row * width + 0] = pred_left1 as u16;
-      out[row * width + 1] = pred_left2 as u16;
+      // A valid PEF frame has an even width >= 2, so every write here is in
+      // bounds; guard against a crafted width of 1 (or an odd width on the last
+      // column) indexing past the buffer. The huffman decode runs unconditionally
+      // so the bitstream position is preserved.
+      if let Some(slot) = out.pixels_mut().get_mut(row * width) {
+        *slot = pred_left1 as u16;
+      }
+      if let Some(slot) = out.pixels_mut().get_mut(row * width + 1) {
+        *slot = pred_left2 as u16;
+      }
       for col in (2..width).step_by(2) {
         pred_left1 += htable.huff_decode(&mut pump)?;
         pred_left2 += htable.huff_decode(&mut pump)?;
-        out[row * width + col + 0] = pred_left1 as u16;
-        out[row * width + col + 1] = pred_left2 as u16;
+        if let Some(slot) = out.pixels_mut().get_mut(row * width + col) {
+          *slot = pred_left1 as u16;
+        }
+        if let Some(slot) = out.pixels_mut().get_mut(row * width + col + 1) {
+          *slot = pred_left2 as u16;
+        }
       }
     }
     Ok(out)

--- a/rawler/src/decoders/raf.rs
+++ b/rawler/src/decoders/raf.rs
@@ -161,7 +161,14 @@ fn parse_raf(file: &RawSource) -> Result<IFD> {
   let offset = stream.read_u32::<BigEndian>()?;
 
   // Main IFD
-  let mut main = IFD::new_root(stream, offset + 12)?;
+  // `offset` is a file-supplied pointer; `offset + 12` overflows u32 when the
+  // file specifies a near-u32::MAX pointer. For a valid RAF the TIFF1 pointer is
+  // a small in-file offset, so this addition never overflows on well-formed
+  // input; a corrupt pointer becomes a decode error instead of a panic.
+  let main_base = offset
+    .checked_add(12)
+    .ok_or_else(|| RawlerError::DecoderFailed(format!("RAF: TIFF1 offset {} overflows", offset)))?;
+  let mut main = IFD::new_root(stream, main_base)?;
 
   //main.dump::<TiffCommonTag>(10).iter().for_each(|line| eprintln!("MAIN: {}", line));
 

--- a/rawler/src/decoders/rw2/v4decompressor.rs
+++ b/rawler/src/decoders/rw2/v4decompressor.rs
@@ -9,7 +9,10 @@ pub(crate) fn decode_panasonic_v4(buf: &[u8], width: usize, height: usize, split
     &(|out: &mut [u16], _strip, row| {
       let skip = ((width * row * 9) + (width / 14 * 2 * row)) / 8;
       let blocks = skip / 0x4000;
-      let src = &buf[blocks * 0x4000..];
+      // `buf` length depends on the file; a short/corrupt buffer makes this
+      // block offset exceed it. A valid RW2 strip lies inside the buffer, so the
+      // `get` succeeds and the decode is unchanged.
+      let src = buf.get(blocks * 0x4000..).ok_or("Panasonic v4: strip offset out of range")?;
       let mut pump = BitPumpPanasonic::new(src, split);
       for _ in 0..(skip % 0x4000) {
         pump.get_bits(8);

--- a/rawler/src/decoders/srw.rs
+++ b/rawler/src/decoders/srw.rs
@@ -6,6 +6,7 @@ use crate::RawLoader;
 use crate::RawlerError;
 use crate::Result;
 use crate::alloc_image;
+use crate::alloc_image_ok;
 use crate::analyze::FormatDump;
 use crate::bits::LEu32;
 use crate::bits::clampbits;
@@ -106,7 +107,7 @@ impl<'a> Decoder for SrwDecoder<'a> {
         }
       },
       32772 => SrwDecoder::decode_srw2(&src, width, height, dummy),
-      32773 => SrwDecoder::decode_srw3(&src, width, height, dummy),
+      32773 => SrwDecoder::decode_srw3(&src, width, height, dummy)?,
       x => {
         return Err(RawlerError::unsupported(
           &self.camera,
@@ -140,7 +141,12 @@ impl<'a> SrwDecoder<'a> {
     for row in 0..height {
       let mut len: [u32; 4] = [if row < 2 { 7 } else { 4 }; 4];
       let loffset = LEu32(loffsets, row * 4) as usize;
-      let mut pump = BitPumpMSB32::new(&buf[loffset..]);
+      // `loffset` is a per-row offset read from the (untrusted) line-offset table
+      // and can point past `buf` on a corrupt file. For a valid SRW1 stream each
+      // row offset lands inside the buffer, so this is the same slice; an
+      // out-of-range offset yields an empty bitstream (decoding zeros) instead of
+      // panicking.
+      let mut pump = BitPumpMSB32::new(buf.get(loffset..).unwrap_or(&[]));
 
       let img = width * row;
       let img_up = width * (cmp::max(1, row) - 1);
@@ -154,8 +160,11 @@ impl<'a> SrwDecoder<'a> {
         for (i, op) in ops.iter().enumerate() {
           match *op {
             3 => len[i] = pump.get_bits(4),
-            2 => len[i] -= 1,
-            1 => len[i] += 1,
+            // For a valid SRW1 the op sequence keeps `len` in a sane bit-count
+            // range, so these never underflow/overflow; saturating arithmetic is
+            // identical for valid input and avoids a panic on a crafted op stream.
+            2 => len[i] = len[i].saturating_sub(1),
+            1 => len[i] = len[i].saturating_add(1),
             _ => {}
           }
         }
@@ -164,14 +173,20 @@ impl<'a> SrwDecoder<'a> {
         for c in (0..16).step_by(2) {
           let l = len[c >> 3];
           let adj = pump.get_ibits_sextended(l);
-          let predictor = if dir {
-            // Upward prediction
-            out[img_up + col + c]
-          } else {
-            // Left to right prediction
-            if col == 0 { 128 } else { out[img + col - 2] }
-          };
+          // The predictor is only used to write a pixel that lies inside the
+          // image (`col + c < width`), and the upward read `out[img_up + col + c]`
+          // is in bounds exactly when that holds. For a valid SRW1 frame (width a
+          // multiple of 16) the read is always in range; computing the predictor
+          // only when the pixel is in-image leaves valid output unchanged while
+          // avoiding an out-of-bounds read on a crafted non-multiple-of-16 width.
           if col + c < width {
+            let predictor = if dir {
+              // Upward prediction
+              out[img_up + col + c]
+            } else {
+              // Left to right prediction
+              if col == 0 { 128 } else { out[img + col - 2] }
+            };
             // No point in decoding pixels outside the image
             out[img + col + c] = ((predictor as i32) + adj) as u16;
           }
@@ -180,14 +195,14 @@ impl<'a> SrwDecoder<'a> {
         for c in (1..16).step_by(2) {
           let l = len[2 | (c >> 3)];
           let adj = pump.get_ibits_sextended(l);
-          let predictor = if dir {
-            // Upward prediction
-            out[img_up2 + col + c]
-          } else {
-            // Left to right prediction
-            if col == 0 { 128 } else { out[img + col - 1] }
-          };
           if col + c < width {
+            let predictor = if dir {
+              // Upward prediction
+              out[img_up2 + col + c]
+            } else {
+              // Left to right prediction
+              if col == 0 { 128 } else { out[img + col - 1] }
+            };
             // No point in decoding pixels outside the image
             out[img + col + c] = ((predictor as i32) + adj) as u16;
           }
@@ -198,9 +213,18 @@ impl<'a> SrwDecoder<'a> {
     // SRW1 apparently has red and blue swapped, just changing the CFA pattern to
     // match causes color fringing in high contrast areas because the actual pixel
     // locations would not match the CFA pattern
+    let pixel_count = width * height;
     for row in (0..height).step_by(2) {
       for col in (0..width).step_by(2) {
-        out.pixels_mut().swap(row * width + col + 1, (row + 1) * width + col);
+        // For a valid SRW1 (even width and height, Bayer layout) both swap
+        // indices are always in bounds; only a crafted odd width/height pushes
+        // `(row + 1) * width + col` past the end. Skip the out-of-range swap
+        // instead of panicking — valid frames swap exactly as before.
+        let a = row * width + col + 1;
+        let b = (row + 1) * width + col;
+        if a < pixel_count && b < pixel_count {
+          out.pixels_mut().swap(a, b);
+        }
       }
     }
 
@@ -286,7 +310,7 @@ impl<'a> SrwDecoder<'a> {
     diff
   }
 
-  pub fn decode_srw3(buf: &[u8], width: usize, height: usize, dummy: bool) -> PixU16 {
+  pub fn decode_srw3(buf: &[u8], width: usize, height: usize, dummy: bool) -> std::result::Result<PixU16, String> {
     // Decoder for third generation compressed SRW files (NX1)
     // Seriously Samsung just use lossless jpeg already, it compresses better too :)
 
@@ -294,7 +318,7 @@ impl<'a> SrwDecoder<'a> {
     // and Loring von Palleske (Samsung) for pointing to the open-source code of
     // Samsung's DNG converter at http://opensource.samsung.com/
 
-    let mut out = alloc_image!(width, height, dummy);
+    let mut out = alloc_image_ok!(width, height, dummy);
     let mut pump = BitPumpMSB32::new(buf);
 
     // Process the initial metadata bits, we only really use initVal, width and
@@ -335,7 +359,11 @@ impl<'a> SrwDecoder<'a> {
       if (line_offset & 0x0f) != 0 {
         line_offset += 16 - (line_offset & 0xf);
       }
-      pump = BitPumpMSB32::new(&buf[line_offset..]);
+      // `line_offset` accumulates from per-line bit positions; for a valid NX1
+      // stream each line starts within the buffer, so this slice is unchanged. A
+      // corrupt stream that walks past the end yields an empty (exhaustion-safe)
+      // bit pump instead of panicking.
+      pump = BitPumpMSB32::new(buf.get(line_offset..).unwrap_or(&[]));
 
       let img = width * row;
       let img_up = width * (cmp::max(1, row) - 1);
@@ -370,41 +398,70 @@ impl<'a> SrwDecoder<'a> {
         }
 
         if row < 2 && motion != 7 {
-          panic!("SRW Decoder: At start of image and motion isn't 7. File corrupted?")
+          // Reachable only on a corrupt stream (a valid NX1 always has motion==7
+          // on the first two rows); return an error instead of panicking.
+          return Err("SRW Decoder: At start of image and motion isn't 7. File corrupted?".to_string());
         }
 
         if motion == 7 {
           // The base case, just set all pixels to the previous ones on the same line
           // If we're at the left edge we just start at the initial value
+          // For a valid NX1 frame (width a multiple of 16) `img + col + i` is
+          // always in bounds; guard against a crafted non-multiple-of-16 width
+          // that would index past the buffer. The same-line back-reference
+          // (`- 2`) reads a previously-written pixel and is read as 0 if missing.
           for i in 0..16 {
-            out[img + col + i] = if col == 0 { init_val } else { out[img + col + i - 2] };
+            let value = if col == 0 {
+              init_val
+            } else {
+              out.pixels().get(img + col + i - 2).copied().unwrap_or(0)
+            };
+            if let Some(slot) = out.pixels_mut().get_mut(img + col + i) {
+              *slot = value;
+            }
           }
         } else {
           // The complex case, we now need to actually lookup one or two lines above
           if row < 2 {
-            panic!("SRW: Got a previous line lookup on first two lines. File corrupted?");
+            // Reachable only on a corrupt stream; a valid NX1 never does a
+            // previous-line lookup on the first two rows.
+            return Err("SRW: Got a previous line lookup on first two lines. File corrupted?".to_string());
           }
+          // `motion` is bounded to 0..=7 by the 3-bit reads above, but guard the
+          // table index defensively.
           let motion_offset: [isize; 7] = [-4, -2, -2, 0, 0, 2, 4];
           let motion_average: [i32; 7] = [0, 0, 1, 0, 1, 0, 0];
-          let slide_offset = motion_offset[motion];
+          let slide_offset = *motion_offset.get(motion).ok_or("SRW: motion index out of range")?;
+          let motion_avg = *motion_average.get(motion).ok_or("SRW: motion index out of range")?;
 
           for i in 0..16 {
-            let refpixel: usize = if ((row + i) & 0x1) != 0 {
+            let refpixel: isize = if ((row + i) & 0x1) != 0 {
               // Red or blue pixels use same color two lines up
-              ((img_up2 + col + i) as isize + slide_offset) as usize
+              (img_up2 + col + i) as isize + slide_offset
             } else {
               // Green pixel N uses Green pixel N from row above (top left or top right)
               if (i % 2) != 0 {
-                ((img_up + col + i - 1) as isize + slide_offset) as usize
+                (img_up + col + i - 1) as isize + slide_offset
               } else {
-                ((img_up + col + i + 1) as isize + slide_offset) as usize
+                (img_up + col + i + 1) as isize + slide_offset
               }
             };
+            // `refpixel` is computed with a signed slide offset; for a valid NX1
+            // it always lands inside the buffer, but a corrupt stream can push it
+            // negative or past the end. Read 0 for an out-of-range reference
+            // instead of panicking (or wrapping a negative index to a huge usize).
+            let get_ref = |p: isize| -> u16 { if p < 0 { 0 } else { out.pixels().get(p as usize).copied().unwrap_or(0) } };
             // In some cases we use as reference interpolation of this pixel and the next
-            out[img + col + i] = if motion_average[motion] != 0 {
-              (out[refpixel] + out[refpixel + 2] + 1) >> 1
+            let value = if motion_avg != 0 {
+              // Average two reference pixels. Widen to u32 for the sum: two
+              // in-range pixels can sum past u16::MAX, overflowing the u16 add
+              // (the `>> 1` brings it back in range). Identical for valid pixels.
+              (((get_ref(refpixel) as u32) + (get_ref(refpixel + 2) as u32) + 1) >> 1) as u16
             } else {
-              out[refpixel]
+              get_ref(refpixel)
+            };
+            if let Some(slot) = out.pixels_mut().get_mut(img + col + i) {
+              *slot = value;
             }
           }
         }
@@ -424,7 +481,10 @@ impl<'a> SrwDecoder<'a> {
                 diff_bits[i] = diff_bits_mode[colornum][0] + 1;
               }
               2 => {
-                diff_bits[i] = diff_bits_mode[colornum][0] - 1;
+                // A valid stream keeps `diff_bits_mode[..][0] >= 1` here; guard
+                // the subtraction against a corrupt 0 value (saturating matches
+                // the valid case where the value is always >= 1).
+                diff_bits[i] = diff_bits_mode[colornum][0].saturating_sub(1);
               }
               3 => {
                 diff_bits[i] = pump.get_bits(4);
@@ -434,7 +494,9 @@ impl<'a> SrwDecoder<'a> {
             diff_bits_mode[colornum][0] = diff_bits_mode[colornum][1];
             diff_bits_mode[colornum][1] = diff_bits[i];
             if diff_bits[i] > bit_depth + 1 {
-              panic!("SRW Decoder: Too many difference bits. File corrupted?");
+              // Reachable only on a corrupt stream; return an error instead of
+              // panicking.
+              return Err("SRW Decoder: Too many difference bits. File corrupted?".to_string());
             }
           }
         }
@@ -452,12 +514,17 @@ impl<'a> SrwDecoder<'a> {
             ((i & 0x7) << 1) + (i >> 3)
           } + img
             + col;
-          out[pos] = clampbits((out[pos] as i32) + diff, bit_depth);
+          // `pos` is bounded for a valid NX1 frame; guard against a corrupt
+          // stream pushing it past the buffer end (e.g. a non-multiple-of-16
+          // width) by skipping the out-of-range write.
+          if let Some(slot) = out.pixels_mut().get_mut(pos) {
+            *slot = clampbits((*slot as i32) + diff, bit_depth);
+          }
         }
       }
     }
 
-    out
+    Ok(out)
   }
 
   /// Get lens description by analyzing TIFF tags and makernotes

--- a/rawler/src/decoders/unwrapped.rs
+++ b/rawler/src/decoders/unwrapped.rs
@@ -11,10 +11,24 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
   let decoder = LEu16(&buffer, 0);
   let width = LEu16(&buffer, 2) as usize;
   let height = LEu16(&buffer, 4) as usize;
-  let data = &buffer[6..];
+  // This is a fuzzing/test-only entry point; the 6-byte header (decoder, width,
+  // height) is followed by the payload. Guard the slice so a sub-6-byte input
+  // errors instead of panicking. The `LEu*` readers above are already EOF-safe.
+  let data = buffer.get(6..).ok_or("Unwrapped: input too small for header")?;
 
   if width > 64 || height > 64 {
     return Err(RawlerError::DecoderFailed(format!("Unwrapped: image {}x{} exceeds 64x64 limit", width, height)));
+  }
+  // Several unwrapped decoders below call into helpers that `.expect()` a
+  // successful decompress (e.g. Panasonic v4), and a 0-width/0-height image makes
+  // those helpers fail (zero chunk size). A real image has non-zero dimensions,
+  // so rejecting them here is invisible to valid input and keeps the decoders
+  // from hitting an internal panic.
+  if width == 0 || height == 0 {
+    return Err(RawlerError::DecoderFailed(format!(
+      "Unwrapped: image {}x{} has a zero dimension",
+      width, height
+    )));
   }
 
   match decoder {
@@ -26,7 +40,7 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
         }
         LookupTable::new(&t)
       };
-      let data = &data[512..];
+      let data = data.get(512..).ok_or("Unwrapped: input too small for 8bit table data")?;
       Ok(RawImageData::Integer(decompress_8bit_wtable(data, &table, width, height, false)?.into_inner()))
     }
     1 => Ok(RawImageData::Integer(decompress_10le_lsb16(data, width, height, false)?.into_inner())),
@@ -63,7 +77,7 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
       }
 
       let curve = arw::ArwDecoder::calculate_curve(curve);
-      let data = &data[8..];
+      let data = data.get(8..).ok_or("Unwrapped: input too small for arw2 curve")?;
       Ok(RawImageData::Integer(
         arw::ArwDecoder::decode_arw2(data, width, height, &curve, false)?.into_inner(),
       ))
@@ -71,7 +85,7 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
     23 => {
       let key = LEu32(data, 0);
       let length = LEu16(data, 4) as usize;
-      let data = &data[10..];
+      let data = data.get(10..).ok_or("Unwrapped: input too small for SRF header")?;
 
       if length > 5000 {
         return Err(RawlerError::DecoderFailed(format!("Unwrapped: SRF image length {} exceeds 5000 limit", length)));
@@ -85,13 +99,15 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
     )),
     25 => {
       let loffsets = data;
-      let data = &data[height * 4..];
+      // height <= 64 (checked above), so `height * 4` cannot overflow; guard the
+      // slice for inputs shorter than the line-offset table.
+      let data = data.get(height * 4..).ok_or("Unwrapped: input too small for srw1 line offsets")?;
       Ok(RawImageData::Integer(
         srw::SrwDecoder::decode_srw1(data, loffsets, width, height, false).into_inner(),
       ))
     }
     26 => Ok(RawImageData::Integer(srw::SrwDecoder::decode_srw2(data, width, height, false).into_inner())),
-    27 => Ok(RawImageData::Integer(srw::SrwDecoder::decode_srw3(data, width, height, false).into_inner())),
+    27 => Ok(RawImageData::Integer(srw::SrwDecoder::decode_srw3(data, width, height, false)?.into_inner())),
     28 => Ok(RawImageData::Integer(kdc::KdcDecoder::decode_dc120(data, width, height, false).into_inner())),
     29 => Ok(RawImageData::Integer(
       rw2::v4decompressor::decode_panasonic_v4(data, width, height, false, false).into_inner(),
@@ -107,7 +123,7 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
         }
         LookupTable::new(&t)
       };
-      let data = &data[2048..];
+      let data = data.get(2048..).ok_or("Unwrapped: input too small for kodak65000 table data")?;
       Ok(RawImageData::Integer(
         dcr::DcrDecoder::decode_kodak65000(data, &table, width, height, false).into_inner(),
       ))
@@ -121,14 +137,14 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
     )),
     37 => {
       let huff = data;
-      let data = &data[64..];
+      let data = data.get(64..).ok_or("Unwrapped: input too small for PEF huffman table")?;
       Ok(RawImageData::Integer(
         pef::PefDecoder::do_decode(data, Some((huff, Endian::Little)), width, height, false)?.into_inner(),
       ))
     }
     38 => {
       let huff = data;
-      let data = &data[64..];
+      let data = data.get(64..).ok_or("Unwrapped: input too small for PEF huffman table")?;
       Ok(RawImageData::Integer(
         pef::PefDecoder::do_decode(data, Some((huff, Endian::Big)), width, height, false)?.into_inner(),
       ))
@@ -164,7 +180,8 @@ pub fn decode_unwrapped(file: &RawSource) -> Result<RawImageData> {
     51 => decode_nef(data, width, height, Endian::Big, 14),
     52 => {
       let coeffs = [LEf32(data, 0), LEf32(data, 4), LEf32(data, 8), LEf32(data, 12)];
-      let data = PaddedBuf::new_owned(data[16..].to_vec(), data.len() - 16);
+      let payload = data.get(16..).ok_or("Unwrapped: input too small for snef coeffs")?;
+      let data = PaddedBuf::new_owned(payload.to_vec(), payload.len());
       Ok(RawImageData::Integer(
         nef::NefDecoder::decode_snef_compressed(&data, coeffs, width, height, false)?.into_inner(),
       ))
@@ -182,7 +199,7 @@ fn decode_ljpeg(src: &[u8], width: usize, height: usize, dng_bug: bool, csfix: b
 
 fn decode_nef(data: &[u8], width: usize, height: usize, endian: Endian, bps: usize) -> Result<RawImageData> {
   let meta = data;
-  let data = &data[4096..];
+  let data = data.get(4096..).ok_or("Unwrapped: input too small for NEF metadata block")?;
   Ok(RawImageData::Integer(
     nef::NefDecoder::do_decode(data, meta, endian, width, height, bps, false)?.into_inner(),
   ))

--- a/rawler/src/decoders/x3f.rs
+++ b/rawler/src/decoders/x3f.rs
@@ -39,8 +39,15 @@ struct X3fImage {
 impl X3fFile {
   fn new(file: &RawSource) -> Result<X3fFile> {
     let buf = file.as_vec()?;
-    let offset = LEu32(&buf, buf.len() - 4) as usize;
-    let data = &buf[offset..];
+    // The directory pointer lives in the last 4 bytes of the file. A truncated
+    // file (< 4 bytes) has no such pointer; reject it instead of underflowing
+    // `buf.len() - 4`. A well-formed X3F is always far larger than 4 bytes.
+    let dir_ptr_pos = buf.len().checked_sub(4).ok_or("X3F: file too small to contain directory pointer")?;
+    let offset = LEu32(&buf, dir_ptr_pos) as usize;
+    // `offset` is read from the (untrusted) file and may point past EOF; for a
+    // valid X3F it points at the in-file directory, so `get` succeeds and
+    // behaviour is unchanged.
+    let data = buf.get(offset..).ok_or("X3F: directory offset out of range")?;
     let version = LEu32(data, 4);
     if version < 0x00020000 {
       return Err(format_args!("X3F: Directory version too old {}", version).into());
@@ -63,10 +70,14 @@ impl X3fFile {
 
 impl X3fDirectory {
   fn new(buf: &[u8], offset: usize) -> Result<X3fDirectory> {
-    let data = &buf[offset..];
+    // `offset` is derived from a file-supplied directory pointer and entry
+    // index; a corrupt file can push it past EOF. For a valid file each
+    // directory entry is 12 bytes inside the file, so this slice always
+    // succeeds and the parse is unchanged.
+    let data = buf.get(offset..).ok_or("X3F: directory entry offset out of range")?;
     let off = LEu32(data, 0) as usize;
     let len = LEu32(data, 4) as usize;
-    let name = String::from_utf8_lossy(&data[8..12]).to_string();
+    let name = String::from_utf8_lossy(data.get(8..12).ok_or("X3F: truncated directory entry")?).to_string();
 
     Ok(X3fDirectory { offset: off, len, id: name })
   }
@@ -74,7 +85,12 @@ impl X3fDirectory {
 
 impl X3fImage {
   fn new(buf: &[u8], offset: usize) -> Result<X3fImage> {
-    let data = &buf[offset..];
+    // `offset` comes from a directory entry's file-supplied offset field and
+    // can be out of range for a corrupt file; valid IMA2 entries point inside
+    // the file so the slice succeeds and the field reads are unchanged. The
+    // `LEu*` readers are themselves EOF-safe, but we still need a valid base
+    // slice to index from.
+    let data = buf.get(offset..).ok_or("X3F: image entry offset out of range")?;
 
     Ok(X3fImage {
       typ: LEu32(data, 8) as usize,
@@ -110,8 +126,15 @@ impl<'a> Decoder for X3fDecoder<'a> {
       .iter()
       .find(|i| i.typ == 2 && i.format == 0x12)
       .ok_or("X3F: Couldn't find camera info")?;
-    let data = &buffer[caminfo.doffset + 6..];
-    if data[0..4] != b"Exif"[..] {
+    // `doffset` originates from the file; on a corrupt file `doffset + 6` can
+    // exceed the buffer. For a valid X3F the camera-info block sits inside the
+    // file, so these reads behave exactly as before.
+    let data = caminfo
+      .doffset
+      .checked_add(6)
+      .and_then(|start| buffer.get(start..))
+      .ok_or("X3F: camera info offset out of range")?;
+    if data.get(0..4) != Some(&b"Exif"[..]) {
       return Err("X3F: Couldn't find EXIF info".into());
     }
     let tiff = IFD::new(&mut Cursor::new(&buffer), (caminfo.doffset + 12) as u32, 0, 0, Endian::Little, &[])?;
@@ -122,7 +145,9 @@ impl<'a> Decoder for X3fDecoder<'a> {
     let width = imginfo.width;
     let height = imginfo.height;
     let offset = imginfo.doffset;
-    let src = &buffer[offset..];
+    // `doffset` is file-derived; guard against an out-of-range image offset on a
+    // corrupt file. A valid image entry points inside the buffer.
+    let src = buffer.get(offset..).ok_or("X3F: image data offset out of range")?;
 
     let image = match imginfo.format {
       35 => self.decode_compressed(src, width, height, dummy)?,

--- a/rawler/src/decompressors/ljpeg/huffman.rs
+++ b/rawler/src/decompressors/ljpeg/huffman.rs
@@ -134,6 +134,14 @@ impl HuffTable {
       for _ in 0..self.bits[len as usize + 1] {
         // Fill for all possible extra bits, payload is always the same for fast lookup bases on peek_bits(self.nbits)
         for _ in 0..(1 << (self.nbits - len - 1)) {
+          // A valid Huffman table satisfies the Kraft inequality, so the filled
+          // slot count never exceeds `hufftable.len()` (= 1 << nbits) and `pos`
+          // stays inside `huffval`. A crafted/over-full code distribution can
+          // overrun both; reject it instead of panicking. Valid tables are
+          // unaffected.
+          if h >= self.hufftable.len() || pos >= self.huffval.len() {
+            return Err("LJPEG: Huffman table is over-full (invalid code lengths)".to_string());
+          }
           self.hufftable[h] = (len as u8 + 1, self.huffval[pos] as u8, self.shiftval[pos] as u8);
           h += 1;
         }

--- a/rawler/src/decompressors/mod.rs
+++ b/rawler/src/decompressors/mod.rs
@@ -145,6 +145,12 @@ where
   F: Fn(&mut [T], usize) -> std::result::Result<(), String> + Sync,
   T: SubPixel,
 {
+  // `par_chunks_mut(width)` panics if `width == 0`. A real image always has a
+  // non-zero width, so this guard only fires on malformed input (e.g. a crafted
+  // 0-width frame), turning the panic into a decode error.
+  if width == 0 {
+    return Err("decompress_lines_fn: image width must not be zero".to_string());
+  }
   let mut out: Pix2D<T> = alloc_image_typed_ok!(T, width, height, dummy);
   out
     .pixels_mut()
@@ -177,6 +183,11 @@ where
   D: for<'a> Decompressor<'a, T>,
   T: SubPixel,
 {
+  // `par_chunks_exact_mut(width)` panics if `width == 0`; a real image has a
+  // non-zero width, so this only guards malformed 0-width input.
+  if width == 0 {
+    return Err("decompress_lines: image width must not be zero".to_string());
+  }
   let mut out: Pix2D<T> = alloc_image_typed_ok!(T, width, height, dummy);
   out
     .pixels_mut()
@@ -212,6 +223,11 @@ where
   F: Fn(&mut [T], usize, usize) -> std::result::Result<(), String> + Sync,
   T: SubPixel,
 {
+  // `par_chunks_mut(width * stripsize)` panics if the chunk size is 0; a real
+  // image has non-zero width and stripsize, so this only guards malformed input.
+  if width == 0 || stripsize == 0 {
+    return Err("decompress_strips_fn: width and stripsize must not be zero".to_string());
+  }
   let mut out: Pix2D<T> = alloc_image_typed_ok!(T, width, height, dummy);
   out
     .pixels_mut()
@@ -249,6 +265,12 @@ where
   D: for<'a> Decompressor<'a, T>,
   T: SubPixel,
 {
+  // `par_chunks_mut(width * stripsize)` and the inner `chunks_exact_mut(width)`
+  // panic on a zero chunk size; a real image has non-zero width and stripsize,
+  // so this only guards malformed input.
+  if width == 0 || stripsize == 0 {
+    return Err("decompress_strips: width and stripsize must not be zero".to_string());
+  }
   let mut out: Pix2D<T> = alloc_image_typed_ok!(T, width, height, dummy);
   out
     .pixels_mut()
@@ -286,6 +308,11 @@ where
   F: Fn(&mut [T], usize) + Sync,
   T: SubPixel,
 {
+  // `par_chunks_mut(chunksize)` panics if `chunksize == 0`; valid callers always
+  // pass a non-zero chunk size, so this only guards malformed input.
+  if chunksize == 0 {
+    return Err("decompress_chunked_fn: chunksize must not be zero".to_string());
+  }
   let mut out: Pix2D<T> = alloc_image_typed_ok!(T, width, height, dummy);
   out.pixels_mut().par_chunks_mut(chunksize).enumerate().for_each(|(chunk_id, chunk)| {
     closure(chunk, chunk_id);

--- a/rawler/src/formats/bmff/ext_cr3/cctp.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cctp.rs
@@ -52,7 +52,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for CctpBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("cctp: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/ext_cr3/cdi1.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cdi1.rs
@@ -45,7 +45,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for Cdi1Box {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("cdi1: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/ext_cr3/cmt1.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cmt1.rs
@@ -21,7 +21,20 @@ impl Cmt1Box {
 impl<R: Read + Seek> ReadBox<&mut R> for Cmt1Box {
   fn read_box(reader: &mut R, header: BoxHeader) -> Result<Self> {
     let current = reader.stream_position()?;
-    let data_len = header.end_offset() - current;
+    // `end_offset() - current` underflows for a corrupt box whose declared end
+    // is before the current position, and (with a near-u64::MAX size) yields a
+    // huge `data_len` that would over-allocate. Compute the length with
+    // `checked_sub` and clamp it to the bytes actually remaining in the stream:
+    // a valid CMT box's payload is fully present, so the clamp is a no-op and the
+    // data read is unchanged; a corrupt box becomes a decode error / bounded read
+    // instead of a panic or OOM.
+    let stream_end = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(current))?;
+    let data_len = header
+      .end_offset()
+      .checked_sub(current)
+      .ok_or_else(|| BmffError::Parse("CMT1: box end before start, corrupt file?".into()))?
+      .min(stream_end.saturating_sub(current));
     let mut data = vec![0; data_len as usize];
     reader.read_exact(&mut data)?;
 

--- a/rawler/src/formats/bmff/ext_cr3/cmt2.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cmt2.rs
@@ -21,7 +21,16 @@ impl Cmt2Box {
 impl<R: Read + Seek> ReadBox<&mut R> for Cmt2Box {
   fn read_box(reader: &mut R, header: BoxHeader) -> Result<Self> {
     let current = reader.stream_position()?;
-    let data_len = header.end_offset() - current;
+    // See Cmt1Box::read_box: guard the length against underflow (corrupt box end
+    // before start) and clamp to remaining stream bytes so a giant declared size
+    // can't over-allocate. Valid boxes are unaffected.
+    let stream_end = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(current))?;
+    let data_len = header
+      .end_offset()
+      .checked_sub(current)
+      .ok_or_else(|| BmffError::Parse("CMT2: box end before start, corrupt file?".into()))?
+      .min(stream_end.saturating_sub(current));
     let mut data = vec![0; data_len as usize];
     reader.read_exact(&mut data)?;
 

--- a/rawler/src/formats/bmff/ext_cr3/cmt3.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cmt3.rs
@@ -21,7 +21,16 @@ impl Cmt3Box {
 impl<R: Read + Seek> ReadBox<&mut R> for Cmt3Box {
   fn read_box(reader: &mut R, header: BoxHeader) -> Result<Self> {
     let current = reader.stream_position()?;
-    let data_len = header.end_offset() - current;
+    // See Cmt1Box::read_box: guard the length against underflow (corrupt box end
+    // before start) and clamp to remaining stream bytes so a giant declared size
+    // can't over-allocate. Valid boxes are unaffected.
+    let stream_end = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(current))?;
+    let data_len = header
+      .end_offset()
+      .checked_sub(current)
+      .ok_or_else(|| BmffError::Parse("CMT3: box end before start, corrupt file?".into()))?
+      .min(stream_end.saturating_sub(current));
     let mut data = vec![0; data_len as usize];
     reader.read_exact(&mut data)?;
 

--- a/rawler/src/formats/bmff/ext_cr3/cmt4.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cmt4.rs
@@ -21,7 +21,16 @@ impl Cmt4Box {
 impl<R: Read + Seek> ReadBox<&mut R> for Cmt4Box {
   fn read_box(reader: &mut R, header: BoxHeader) -> Result<Self> {
     let current = reader.stream_position()?;
-    let data_len = header.end_offset() - current;
+    // See Cmt1Box::read_box: guard the length against underflow (corrupt box end
+    // before start) and clamp to remaining stream bytes so a giant declared size
+    // can't over-allocate. Valid boxes are unaffected.
+    let stream_end = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(current))?;
+    let data_len = header
+      .end_offset()
+      .checked_sub(current)
+      .ok_or_else(|| BmffError::Parse("CMT4: box end before start, corrupt file?".into()))?
+      .min(stream_end.saturating_sub(current));
     let mut data = vec![0; data_len as usize];
     reader.read_exact(&mut data)?;
 

--- a/rawler/src/formats/bmff/ext_cr3/cr3desc.rs
+++ b/rawler/src/formats/bmff/ext_cr3/cr3desc.rs
@@ -91,7 +91,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for Cr3DescBox {
         _ => return Err(BmffError::Parse(format!("Unknown box in Cr3desc: {}", header.typ))),
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("cr3desc: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/ext_cr3/craw.rs
+++ b/rawler/src/formats/bmff/ext_cr3/craw.rs
@@ -103,7 +103,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for CrawBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("craw: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/ftyp.rs
+++ b/rawler/src/formats/bmff/ftyp.rs
@@ -26,7 +26,14 @@ impl<R: Read + Seek> ReadBox<&mut R> for FtypBox {
     if header.size % 4 != 0 {
       return Err(BmffError::Parse("invalid ftyp size".into()));
     }
-    let brand_count = (header.size - 16) / 4; // header + major + minor
+    // `size - 16` underflows for a corrupt ftyp smaller than its fixed header
+    // (8) + major (4) + minor (4) = 16 bytes. A valid ftyp is always >= 16, so
+    // this check never fires on well-formed input.
+    let brand_count = header
+      .size
+      .checked_sub(16)
+      .ok_or_else(|| BmffError::Parse("invalid ftyp size (too small)".into()))?
+      / 4; // header + major + minor
 
     let mut brands = Vec::new();
     for _ in 0..brand_count {

--- a/rawler/src/formats/bmff/mdia.rs
+++ b/rawler/src/formats/bmff/mdia.rs
@@ -55,7 +55,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for MdiaBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("mdia: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/minf.rs
+++ b/rawler/src/formats/bmff/minf.rs
@@ -56,7 +56,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for MinfBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("minf: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/mod.rs
+++ b/rawler/src/formats/bmff/mod.rs
@@ -92,7 +92,12 @@ impl BoxHeader {
   }
 
   pub fn end_offset(&self) -> u64 {
-    self.offset + self.size
+    // Saturating add: a corrupt box can declare a near-u64::MAX `size`, making
+    // `offset + size` overflow. A real BMFF box always ends well within u64, so
+    // the saturating sum is identical for valid input; for a corrupt size the
+    // clamp to u64::MAX makes the subsequent seek land past EOF (terminating the
+    // box loop) instead of panicking under overflow checks.
+    self.offset.saturating_add(self.size)
   }
 
   pub fn make_view<'a>(&self, buffer: &'a [u8], skip: usize, limit: usize) -> &'a [u8] {

--- a/rawler/src/formats/bmff/moov.rs
+++ b/rawler/src/formats/bmff/moov.rs
@@ -66,7 +66,16 @@ impl<R: Read + Seek> ReadBox<&mut R> for MoovBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // A child box that did not advance the cursor (corrupt/zero-size box)
+        // would otherwise loop forever, pushing entries until the Vec exhausts
+        // memory. A valid moov always advances past each child, so this guard
+        // never fires on well-formed input. Mirrors the same guard in
+        // `FileBox::parse`.
+        return Err(BmffError::Parse("moov: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/stbl.rs
+++ b/rawler/src/formats/bmff/stbl.rs
@@ -93,7 +93,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for StblBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("stbl: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/stsd.rs
+++ b/rawler/src/formats/bmff/stsd.rs
@@ -3,7 +3,7 @@
 // Copyright 2021 Daniel Vogelbacher <daniel@chaospixel.com>
 
 use super::{
-  BoxHeader, FourCC, ReadBox, Result,
+  BmffError, BoxHeader, FourCC, ReadBox, Result,
   ext_cr3::{craw::CrawBox, ctmd::CtmdBox},
   read_box_header_ext,
   vendor::VendorBox,
@@ -63,7 +63,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("stsd: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/trak.rs
+++ b/rawler/src/formats/bmff/trak.rs
@@ -53,7 +53,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
         }
       }
 
-      current = reader.stream_position()?;
+      let new_pos = reader.stream_position()?;
+      if new_pos <= current {
+        // Guard against a non-advancing (corrupt/zero-size) child box that would
+        // otherwise spin forever and exhaust memory. Valid boxes always advance.
+        return Err(BmffError::Parse("trak: child box did not advance, corrupt file?".into()));
+      }
+      current = new_pos;
     }
 
     reader.seek(SeekFrom::Start(header.end_offset()))?;

--- a/rawler/src/formats/bmff/vendor.rs
+++ b/rawler/src/formats/bmff/vendor.rs
@@ -12,7 +12,10 @@ pub struct VendorBox {
 
 impl<R: Read + Seek> ReadBox<&mut R> for VendorBox {
   fn read_box(reader: &mut R, header: BoxHeader) -> Result<Self> {
-    reader.seek(SeekFrom::Start(header.offset + header.size))?;
+    // Use the saturating `end_offset()` instead of `offset + size`, which
+    // overflows for a corrupt near-u64::MAX box size. Valid boxes are unchanged;
+    // a corrupt size seeks past EOF and the box loop terminates.
+    reader.seek(SeekFrom::Start(header.end_offset()))?;
 
     Ok(Self { header })
   }

--- a/rawler/src/formats/ciff/mod.rs
+++ b/rawler/src/formats/ciff/mod.rs
@@ -56,17 +56,31 @@ impl CiffIFD {
     let mut entries = HashMap::new();
     let mut subifds = Vec::new();
 
-    let valuedata_size = LEu32(buf, end - 4) as usize;
-    let dircount = LEu16(buf, start + valuedata_size) as usize;
+    // The CIFF directory layout stores its value-data size in the last 4 bytes
+    // of the [start, end) block. A truncated file where `end < 4` (e.g. an empty
+    // input) would underflow `end - 4`; the directory count offset and entry
+    // offsets are likewise derived from file values and can overflow `usize`.
+    // For a well-formed CIFF every offset stays inside the block, so these
+    // checks never fire on valid input — they only turn a corrupt directory into
+    // a decode error instead of a panic.
+    let valuedata_pos = end.checked_sub(4).ok_or("CIFF: block too small for value-data size")?;
+    let valuedata_size = LEu32(buf, valuedata_pos) as usize;
+    let dircount_pos = start.checked_add(valuedata_size).ok_or("CIFF: value-data offset overflow")?;
+    let dircount = LEu16(buf, dircount_pos) as usize;
 
     for i in 0..dircount {
-      let entry_offset: usize = start + valuedata_size + 2 + i * 10;
+      let entry_offset: usize = start
+        .checked_add(valuedata_size)
+        .and_then(|v| v.checked_add(2))
+        .and_then(|v| i.checked_mul(10).and_then(|im| v.checked_add(im)))
+        .ok_or("CIFF: directory entry offset overflow")?;
       let e = CiffEntry::new(buf, start, entry_offset)?;
       if e.typ == 0x2800 || e.typ == 0x3000 {
         // SubIFDs
         if depth < 10 {
           // Avoid infinite looping IFDs
-          let ifd = CiffIFD::new(buf, e.data_offset, e.data_offset + e.bytesize, depth + 1);
+          let sub_end = e.data_offset.checked_add(e.bytesize).ok_or("CIFF: sub-IFD extent overflow")?;
+          let ifd = CiffIFD::new(buf, e.data_offset, sub_end, depth + 1);
           match ifd {
             Ok(val) => {
               subifds.push(val);
@@ -107,12 +121,26 @@ impl CiffEntry {
 
     let (bytesize, data_offset) = match datalocation {
       // Data is offset in value_data
-      0x0000 => (LEu32(buf, offset + 2) as usize, LEu32(buf, offset + 6) as usize + value_data),
+      0x0000 => (
+        LEu32(buf, offset + 2) as usize,
+        // `data_offset = value_data + stored_offset` is built from file values
+        // and can overflow `usize` on a corrupt entry; a valid entry's offset
+        // lands inside the buffer, so the sum is unchanged for well-formed input.
+        (LEu32(buf, offset + 6) as usize)
+          .checked_add(value_data)
+          .ok_or("CIFF: entry data offset overflow")?,
+      ),
       // Data is stored directly in entry
       0x4000 => (8, offset + 2),
       val => return Err(format!("CIFF: Don't know about data location {:x}", val)),
     };
-    let data = &buf[data_offset..data_offset + bytesize];
+    // `&buf[data_offset..data_offset + bytesize]` indexed directly; both bounds
+    // come from the (untrusted) file and can exceed the buffer or overflow. For
+    // a valid entry the data slice lies inside the buffer, so this `get`
+    // succeeds and the copied data is identical; a corrupt entry becomes a
+    // decode error instead of an out-of-range panic.
+    let data_end = data_offset.checked_add(bytesize).ok_or("CIFF: entry data extent overflow")?;
+    let data = buf.get(data_offset..data_end).ok_or("CIFF: entry data out of range")?;
     let count = bytesize >> CiffEntry::element_shift(typ);
 
     Ok(CiffEntry {

--- a/rawler/src/formats/jfif.rs
+++ b/rawler/src/formats/jfif.rs
@@ -58,8 +58,15 @@ impl<R: Read + Seek> ReadSegment<&mut R> for App0 {
         let ydensity = reader.read_u16::<BigEndian>()?;
         let xthumbnail = reader.read_u8()?;
         let ythumbnail = reader.read_u8()?;
-        let thumbnail = if xthumbnail * ythumbnail > 0 {
-          let mut data = vec![0; (3 * xthumbnail * ythumbnail) as usize];
+        // Widen before multiplying: `xthumbnail * ythumbnail` as `u8 * u8`
+        // overflows (e.g. 16 * 16) and panics under overflow checks. The
+        // widened product is the same value for any real thumbnail size, so
+        // valid files are unaffected; only the overflow panic on crafted
+        // dimensions is removed. The subsequent `read_exact` still bounds the
+        // actual allocation to the bytes present in the file.
+        let thumbnail_pixels = xthumbnail as usize * ythumbnail as usize;
+        let thumbnail = if thumbnail_pixels > 0 {
+          let mut data = vec![0; 3 * thumbnail_pixels];
           reader.read_exact(&mut data)?;
           Some(data)
         } else {
@@ -179,7 +186,16 @@ impl<R: Read + Seek> ReadSegment<&mut R> for App1 {
       reader.read_exact(&mut xmp_str)?;
       if xmp_str == APP1_XMP_MARKER.as_bytes() {
         log::debug!("Found APP1 XMP marker");
-        let mut xpacket = vec![0; len as usize - xmp_str.len() - 2];
+        // `len` includes the 2-byte length field and the XMP marker; a corrupt
+        // `len` smaller than `marker + 2` would underflow this subtraction. The
+        // outer guard only ensures `len >= marker.len()`, not `>= marker.len() +
+        // 2`, so a crafted `len` of exactly the marker length reaches here. A
+        // valid XMP segment always satisfies `len >= marker.len() + 2`, so this
+        // check never fires on well-formed input.
+        let xpacket_len = (len as usize)
+          .checked_sub(xmp_str.len() + 2)
+          .ok_or_else(|| JfifError::General(format!("Invalid APP1 XMP segment length {}", len)))?;
+        let mut xpacket = vec![0; xpacket_len];
         reader.read_exact(&mut xpacket)?;
         reader.seek(SeekFrom::Start(pos + len))?;
         return Ok(Self {
@@ -232,6 +248,15 @@ impl Jfif {
           Ok(app1) => Segment::APP1 { offset: pos, app1 },
           Err(err) => {
             log::warn!("Failed to read APP1 (EXIF) segement, maybe corrupt: {:?}", err);
+            // Advance past this marker before retrying. The bare `continue`
+            // here did not update `sym`/`pos`, so a corrupt/truncated APP1
+            // (e.g. a JFIF with a partial EXIF segment) re-processed the same
+            // stale `0xFFE1` symbol forever. On a well-formed file this branch
+            // is never taken (the segment parses), so reading the next symbol
+            // here only changes the malformed path: we skip the bad segment
+            // and continue marker scanning instead of hanging.
+            pos = reader.stream_position()?;
+            sym = reader.read_u16::<BigEndian>().ok();
             continue;
           }
         },
@@ -243,7 +268,15 @@ impl Jfif {
         _ => {
           log::debug!("Unhandled JFIF segment marker: {:X}", symbol);
           let len: u64 = reader.read_u16::<BigEndian>()? as u64;
-          reader.seek(SeekFrom::Current(len as i64 - 2))?;
+          // A JFIF segment length is inclusive of its own 2-byte length field,
+          // so a well-formed segment always has `len >= 2`. A corrupt `len < 2`
+          // would seek backwards (`len - 2 < 0`) and re-read the same marker
+          // forever; reject it instead. Valid files never take this branch.
+          let skip = (len as i64)
+            .checked_sub(2)
+            .filter(|&n| n >= 0)
+            .ok_or_else(|| JfifError::General(format!("Invalid JFIF segment length {} for marker {:X}", len, symbol)))?;
+          reader.seek(SeekFrom::Current(skip))?;
 
           Segment::Unknown { offset: pos, marker: symbol }
         }

--- a/rawler/src/formats/tiff/entry.rs
+++ b/rawler/src/formats/tiff/entry.rs
@@ -106,6 +106,27 @@ impl Entry {
     }
 
     reader.goto(base + offset)?;
+
+    // Guard against a corrupt `count` driving a huge allocation. Each match arm
+    // allocates `count` elements and then reads that many from the stream; with
+    // an attacker-controlled `count` (up to 4 billion) the allocation happens
+    // *before* the read can fail with EOF, so a truncated file could request
+    // gigabytes. For any well-formed entry the data region `[offset, offset +
+    // bytesize)` lies inside the file, so this check always passes and the
+    // result is unchanged; it only rejects entries whose data extends past EOF,
+    // which would have failed at the subsequent `read_*_into` anyway — we just
+    // turn that EOF into an error before allocating.
+    if bytesize > 4 {
+      let stream_len = reader.stream_len()?;
+      let end = (base as u64) + (offset as u64) + (bytesize as u64);
+      if end > stream_len {
+        return Err(TiffError::Overflow(format!(
+          "Tag 0x{:X}: entry data ({} bytes at offset {}) extends past end of file ({} bytes)",
+          tag, bytesize, offset, stream_len
+        )));
+      }
+    }
+
     let entry = match typ {
       TYPE_BYTE => {
         let mut v = vec![0; count as usize];

--- a/rawler/src/formats/tiff/ifd.rs
+++ b/rawler/src/formats/tiff/ifd.rs
@@ -54,7 +54,11 @@ impl IFD {
   }
 
   pub fn new_root_with_correction<R: Read + Seek>(reader: &mut R, offset: u32, base: u32, corr: i32, max_chain: usize, sub_tags: &[u16]) -> Result<IFD> {
-    reader.seek(SeekFrom::Start((base + offset) as u64))?;
+    // Widen before adding: `base + offset` as `u32 + u32` overflows when the
+    // file supplies a near-u32::MAX IFD pointer, panicking under overflow
+    // checks. The 64-bit sum is the same seek target for any in-file offset, so
+    // valid files are unaffected; an out-of-range target simply fails the read.
+    reader.seek(SeekFrom::Start(base as u64 + offset as u64))?;
     let endian = match reader.read_u16::<LittleEndian>()? {
       0x4949 => Endian::Little,
       0x4d4d => Endian::Big,
@@ -101,7 +105,11 @@ impl IFD {
   }
 
   pub fn new<R: Read + Seek>(reader: &mut R, offset: u32, base: u32, corr: i32, endian: Endian, sub_tags: &[u16]) -> Result<IFD> {
-    reader.seek(SeekFrom::Start((base + offset) as u64))?;
+    // Widen before adding: `base + offset` as `u32 + u32` overflows when the
+    // file supplies a near-u32::MAX IFD pointer, panicking under overflow
+    // checks. The 64-bit sum is the same seek target for any in-file offset, so
+    // valid files are unaffected; an out-of-range target simply fails the read.
+    reader.seek(SeekFrom::Start(base as u64 + offset as u64))?;
     let mut sub_ifd_offsets = HashMap::new();
     let mut reader = EndianReader::new(reader, endian);
     let entry_count = reader.read_u16()?;
@@ -154,7 +162,15 @@ impl IFD {
                 sub_ifd_offsets.insert(tag, offsets.clone());
               }
               Value::Unknown(tag, offsets) => {
-                sub_ifd_offsets.insert(*tag, vec![offsets[0] as u32]);
+                // A SubIFD pointer always carries at least one offset; a corrupt
+                // entry with count 0 leaves `offsets` empty and `offsets[0]`
+                // panics. Skip an empty offset list instead — valid files always
+                // have an offset here, so their behaviour is unchanged.
+                if let Some(&first) = offsets.first() {
+                  sub_ifd_offsets.insert(*tag, vec![first as u32]);
+                } else {
+                  log::warn!("SubIFD entry for tag 0x{:X} has empty offset list, skipping", tag);
+                }
               }
               Value::Undefined(_) => {
                 if let Some(offset) = entry.offset() {
@@ -240,7 +256,11 @@ impl IFD {
 
   /*
   pub fn new<R: Read + Seek>(reader: &mut R, offset: u32, base: u32, corr: i32, endian: Endian, sub_tags: &[u16]) -> Result<Self> {
-    reader.seek(SeekFrom::Start((base + offset) as u64))?;
+    // Widen before adding: `base + offset` as `u32 + u32` overflows when the
+    // file supplies a near-u32::MAX IFD pointer, panicking under overflow
+    // checks. The 64-bit sum is the same seek target for any in-file offset, so
+    // valid files are unaffected; an out-of-range target simply fails the read.
+    reader.seek(SeekFrom::Start(base as u64 + offset as u64))?;
     let mut sub_ifd_offsets = Vec::new();
     let mut reader = EndianReader::new(reader, endian);
     let entry_count = reader.read_u16()?;

--- a/rawler/src/formats/tiff/reader.rs
+++ b/rawler/src/formats/tiff/reader.rs
@@ -291,6 +291,19 @@ impl<'a, R: Read + Seek + 'a> EndianReader<'a, R> {
     Ok(self.inner.stream_position().map(|v| v as u32)?)
   }
 
+  /// Total length of the underlying stream in bytes.
+  ///
+  /// Used to reject entry counts that point past the end of the file *before*
+  /// allocating their backing buffer, so a corrupt count can't drive a huge
+  /// allocation. Restores the original stream position so callers are
+  /// unaffected.
+  pub fn stream_len(&mut self) -> Result<u64> {
+    let cur = self.inner.stream_position()?;
+    let end = self.inner.seek(SeekFrom::End(0))?;
+    self.inner.seek(SeekFrom::Start(cur))?;
+    Ok(end)
+  }
+
   // TODO: try_from?
 
   pub fn goto(&mut self, offset: u32) -> Result<()> {

--- a/rawler/src/pumps.rs
+++ b/rawler/src/pumps.rs
@@ -37,7 +37,13 @@ impl<'a> BitPumpLSB<'a> {
           .fold((0, 0), |(bits, bit_cnt), x| ((bits << 8) | *x as u32, bit_cnt + 8))
       }
     } else {
-      panic!("Can't refill bitpump, buffer exhausted");
+      // Buffer exhausted: yield 32 phantom zero bits instead of panicking. A
+      // valid (correctly-sized) bitstream never refills past its end before the
+      // decode finishes, so this is invisible to well-formed input; a truncated
+      // stream reads zeros past EOF (the same over-read-returns-zero convention
+      // used by the byte readers / PaddedBuf) rather than crashing. Returning a
+      // full 32-bit width keeps `nbits >= num` so `peek_bits` can't underflow.
+      (0, u32::BITS)
     }
   }
 }
@@ -74,7 +80,9 @@ impl<'a> BitPumpMSB<'a> {
         chunk.into_iter().fold((0, 0), |(bits, bit_cnt), x| ((bits << 8) | *x as u32, bit_cnt + 8))
       }
     } else {
-      panic!("Can't refill bitpump, buffer exhausted");
+      // Buffer exhausted: yield 32 phantom zero bits instead of panicking (see
+      // BitPumpLSB::refill for rationale). Invisible to valid bitstreams.
+      (0, u32::BITS)
     }
   }
 }
@@ -116,7 +124,9 @@ impl<'a> BitPumpMSB32<'a> {
           .fold((0, 0), |(bits, bit_cnt), x| ((bits << 8) | *x as u32, bit_cnt + 8))
       }
     } else {
-      panic!("Can't refill bitpump, buffer exhausted");
+      // Buffer exhausted: yield 32 phantom zero bits instead of panicking (see
+      // BitPumpLSB::refill for rationale). Invisible to valid bitstreams.
+      (0, u32::BITS)
     }
   }
 
@@ -216,7 +226,10 @@ impl<'a> BitPump for BitPumpLSB<'a> {
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
-    self.nbits -= num;
+    // `saturating_sub` only differs from `-` when more bits are consumed than
+    // were available, which happens solely on a truncated bitstream; valid
+    // streams never over-consume here.
+    self.nbits = self.nbits.saturating_sub(num);
     self.bits >>= num;
   }
 }
@@ -229,13 +242,17 @@ impl<'a> BitPump for BitPumpMSB<'a> {
       self.bits = (self.bits << bit_cnt) | inbits as u64;
       self.nbits += bit_cnt;
     }
-    (self.bits >> (self.nbits - num)) as u32
+    // `nbits - num` underflows only when a single refill couldn't satisfy `num`
+    // (a truncated final chunk yields < 32 bits). For a valid, complete
+    // bitstream `nbits >= num` always holds here, so the shift is identical;
+    // `saturating_sub` just keeps a truncated stream from panicking.
+    (self.bits >> self.nbits.saturating_sub(num)) as u32
   }
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
-    self.nbits -= num;
-    self.bits &= (1 << self.nbits) - 1;
+    self.nbits = self.nbits.saturating_sub(num);
+    self.bits &= (1u64 << self.nbits) - 1;
   }
 }
 
@@ -248,13 +265,15 @@ impl<'a> BitPump for BitPumpMSB32<'a> {
       self.nbits += bit_cnt;
       self.pos += bit_cnt as usize / 8;
     }
-    (self.bits >> (self.nbits - num)) as u32
+    // `saturating_sub` only diverges from `-` on a truncated bitstream where a
+    // single refill couldn't supply `num` bits; valid streams are unchanged.
+    (self.bits >> self.nbits.saturating_sub(num)) as u32
   }
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
-    self.nbits -= num;
-    self.bits &= (1 << self.nbits) - 1;
+    self.nbits = self.nbits.saturating_sub(num);
+    self.bits &= (1u64 << self.nbits) - 1;
   }
 }
 
@@ -285,7 +304,11 @@ impl<'a> BitPump for BitPumpJPEG<'a> {
               let nextbyte = self.buffer[self.pos];
               if nextbyte != 0xff {
                 nextbyte
-              } else if self.buffer[self.pos + 1] == 0x00 {
+              } else if self.buffer.get(self.pos + 1) == Some(&0x00) {
+                // `buffer[self.pos + 1]` was indexed directly; when the 0xff is
+                // the final byte, `pos + 1` is out of range. Treat a missing
+                // marker byte as "not a stuffed 0x00" (i.e. end of scan), which
+                // matches valid JPEG where the marker byte is always present.
                 self.pos += 1; // Skip the extra byte used to mark 255
                 nextbyte
               } else {
@@ -301,20 +324,22 @@ impl<'a> BitPump for BitPumpJPEG<'a> {
         }
       }
     }
-    if num > self.nbits && self.finished {
-      // Stuff with zeroes to not fail to read
+    while num > self.nbits && self.finished {
+      // Stuff with zeroes to not fail to read. Loop so a `num` larger than a
+      // single 32-bit stuff is still satisfied (valid JPEG never needs this, but
+      // it keeps a truncated stream from underflowing the shift below).
       self.bits <<= 32;
       self.nbits += 32;
     }
 
-    (self.bits >> (self.nbits - num)) as u32
+    (self.bits >> self.nbits.saturating_sub(num)) as u32
   }
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
     debug_assert!(num <= self.nbits);
-    self.nbits -= num;
-    self.bits &= (1 << self.nbits) - 1;
+    self.nbits = self.nbits.saturating_sub(num);
+    self.bits &= (1u64 << self.nbits) - 1;
   }
 }
 
@@ -473,12 +498,14 @@ impl<'a> BitPump for BitPumpReverseBitsMSB<'a> {
       self.pos += 4;
       self.nbits += 32;
     }
-    (self.bits >> (self.nbits - num)) as u32
+    // Defensive `saturating_sub` (a single 32-bit refill always satisfies the
+    // asserted `num <= 32`, so this is identical for valid use).
+    (self.bits >> self.nbits.saturating_sub(num)) as u32
   }
 
   #[inline(always)]
   fn consume_bits(&mut self, num: u32) {
-    self.nbits -= num;
-    self.bits &= (1 << self.nbits) - 1;
+    self.nbits = self.nbits.saturating_sub(num);
+    self.bits &= (1u64 << self.nbits) - 1;
   }
 }


### PR DESCRIPTION
## Summary

Make `rawler` panic-free on malformed/untrusted input across all 8 libFuzzer targets, without changing decoded output for any well-formed file.

A RAW decoder routinely derives buffer offsets/lengths/loop bounds from values stored in the (untrusted) input file, so a crafted file can drive out-of-range slice indices, integer under/overflow, zero-size work splits, non-advancing container loops, and `panic!`/`unwrap()`/`assert!` sites. Each is a denial-of-service on untrusted input (the public `decode` wraps decoders in `catch_unwind`, but the lower-level APIs and `panic = "abort"` builds still abort, and unbounded allocations OOM regardless).

## What changed

1. **EOF-safe byte readers** (`bits.rs`): the free `LEu16`/`BEu16`/`LEu32`/… readers and the `Endian::read_*` methods return 0 on an out-of-range offset instead of panicking (dcraw / `PaddedBuf` convention). 123 call sites.
2. **Bit pumps** (`pumps.rs`): exhaustion yields phantom zero bits (same convention) instead of `panic!`; `peek/consume` use `saturating_sub`. This is the high-leverage fix — every entropy decoder (LJPEG, PEF, ORF, NEF, SRW, ARW) routes through these.
3. **Container/format parsers**: bounds-checked slicing + `checked_add/sub` in TIFF/CIFF/BMFF/JFIF/RAF/MRW; "cursor must advance" guards on the 10 BMFF box loops (kills unbounded `Vec` growth / OOM); reject zero-size work splits (`par_chunks_mut(0)`); reject over-full Huffman tables (Kraft).
4. **Per-decoder arithmetic**: x3f/orf/nef/srw/pef/arw/kdc predictor + row-offset paths made bounds-safe; overflow-prone products widened or made `wrapping`/`saturating` to match the existing release behavior.

Every fix is structured so its error/default branch is reachable **only** on malformed input — on a well-formed file the value/logic is unchanged. `#![forbid(unsafe_code)]` respected; no `catch_unwind` added; encode/write paths untouched.

## Verification

- **All 8 fuzz targets** run clean (no crash / slow-unit / OOM) for 120 s ×2 each, plus an all-targets re-run; the original CIFF/X3F/JFIF/BMFF repros are now handled gracefully. (Regression corpus: 27 minimized inputs.)
- **No pixel-output regression**: rawler's own rawdb digest suite passes — 13 real samples across every changed decoder (Nikon sNEF + lossless NEF, Olympus ORF ×2, Samsung SRW + NX1, Sony ARW, Panasonic RW2, Fuji RAF, Pentax PEF, Minolta MRW, Kodak DC120, Canon CR2/LJPEG) decode **bit-identically** to the committed reference digests.
- `cargo build --release` clean; `cargo test` 59 unit + 6 doctests pass; `cargo clippy` no new lints.

## Not covered (out of scope / not reached)

A few latent sites the fuzzers didn't reach in-budget and that need real-camera detection paths are flagged in the PR discussion rather than changed pre-emptively (e.g. `bmff/mod.rs:98` dead `make_view`, a couple of `decoders/*` arithmetic spots only reachable via specific real files). They can be follow-ups.
