### PR TITLE
ci: restore fork PR and RawDB validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,11 @@ on:
     paths-ignore:
       - '**.md'
       - '.github/workflows/release.yaml'
-  pull_request_target:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -42,6 +46,9 @@ jobs:
 
   rawdb:
     name: Testdata validation with Rust ${{matrix.rust}}
+    # Never execute fork PR code with repository secrets on the self-hosted runner.
+    # Maintainers can dispatch this workflow on a reviewed repository branch.
+    if: github.event_name != 'pull_request'
     runs-on: testdata-avail
     environment: builddrone
     strategy:
@@ -54,8 +61,6 @@ jobs:
       RAYON_NUM_THREADS: 4
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,30 +44,6 @@ jobs:
       - run: cargo build --all-features
       - run: cargo check --all-features
 
-  rawdb:
-    name: Testdata validation with Rust ${{matrix.rust}}
-    # Never execute fork PR code with repository secrets on the self-hosted runner.
-    # Maintainers can dispatch this workflow on a reviewed repository branch.
-    if: github.event_name != 'pull_request'
-    runs-on: testdata-avail
-    environment: builddrone
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [1.89.0]
-    env:
-      RAWDB_CACHE: /opt/rawdb_cache
-      RAWDB_API_KEY_REQUIRED: "true"
-      RAYON_NUM_THREADS: 4
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{matrix.rust}}
-      - run: cargo test --release --features rawdb
-        env:
-          RAWDB_API_KEY: ${{ secrets.RAWDB_API_KEY }}
-
   windows_check:
     name: Windows check
     runs-on: windows-latest

--- a/.github/workflows/rawdb.yaml
+++ b/.github/workflows/rawdb.yaml
@@ -74,10 +74,11 @@ jobs:
       RAWDB_API_KEY_REQUIRED: "true"
       RAYON_NUM_THREADS: 4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
-      - uses: dtolnay/rust-toolchain@master
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{matrix.rust}}
       - run: cargo test --release --features rawdb

--- a/.github/workflows/rawdb.yaml
+++ b/.github/workflows/rawdb.yaml
@@ -1,0 +1,85 @@
+name: RawDB validation
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/release.yaml'
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Full SHA at a reviewed dnglab/dnglab branch tip; dispatch from main
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# SECURITY: testdata-avail must belong to a runner group restricted to
+# dnglab/dnglab/.github/workflows/rawdb.yaml@refs/heads/main. Without that
+# repository-level policy, a fork PR could target the self-hosted runner from
+# a modified or newly added workflow. If workflow-level runner restrictions
+# are unavailable, do not expose this runner to the public repository.
+jobs:
+  resolve-ref:
+    name: Resolve trusted revision
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - name: Resolve and validate revision
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            commit_sha="$EVENT_SHA"
+          else
+            commit_sha="$REQUESTED_SHA"
+            if [[ ! "$commit_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "commit_sha must be a full 40-character commit SHA" >&2
+              exit 1
+            fi
+            commit_sha=$(printf '%s' "$commit_sha" | tr '[:upper:]' '[:lower:]')
+
+            if ! git ls-remote "https://github.com/${REPOSITORY}.git" 'refs/heads/*' |
+              awk -v sha="$commit_sha" '$1 == sha { found = 1 } END { exit !found }'; then
+              echo "commit_sha must be the current tip of a branch in ${REPOSITORY}" >&2
+              exit 1
+            fi
+          fi
+
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+  rawdb:
+    name: Testdata validation with Rust ${{matrix.rust}}
+    needs: resolve-ref
+    runs-on: testdata-avail
+    environment: builddrone
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [1.89.0]
+    env:
+      RAWDB_CACHE: /opt/rawdb_cache
+      RAWDB_API_KEY_REQUIRED: "true"
+      RAYON_NUM_THREADS: 4
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{matrix.rust}}
+      - run: cargo test --release --features rawdb
+        env:
+          RAWDB_API_KEY: ${{ secrets.RAWDB_API_KEY }}

--- a/.github/workflows/rawdb.yaml
+++ b/.github/workflows/rawdb.yaml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**.md'
       - '.github/workflows/release.yaml'
+  pull_request_target:
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -17,15 +18,14 @@ on:
 permissions:
   contents: read
 
-# SECURITY: testdata-avail must belong to a runner group restricted to
-# dnglab/dnglab/.github/workflows/rawdb.yaml@refs/heads/main. Without that
-# repository-level policy, a fork PR could target the self-hosted runner from
-# a modified or newly added workflow. If workflow-level runner restrictions
-# are unavailable, do not expose this runner to the public repository.
+# SECURITY: builddrone approval is the primary gate before pull request code
+# reaches testdata-avail. Restricting the runner group to
+# dnglab/dnglab/.github/workflows/rawdb.yaml@refs/heads/main is recommended as
+# defense in depth so no other workflow can target the self-hosted runner.
 jobs:
   resolve-ref:
-    name: Resolve trusted revision
-    if: github.ref == 'refs/heads/main'
+    name: Resolve validation revision
+    if: github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     outputs:
       commit_sha: ${{ steps.resolve.outputs.commit_sha }}
@@ -36,21 +36,35 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SHA: ${{ github.sha }}
+          PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
           REQUESTED_SHA: ${{ inputs.commit_sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            commit_sha="$EVENT_SHA"
-          else
-            commit_sha="$REQUESTED_SHA"
-            if [[ ! "$commit_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
-              echo "commit_sha must be a full 40-character commit SHA" >&2
+          case "$EVENT_NAME" in
+            pull_request_target)
+              commit_sha="$PULL_REQUEST_SHA"
+              ;;
+            push)
+              commit_sha="$EVENT_SHA"
+              ;;
+            workflow_dispatch)
+              commit_sha="$REQUESTED_SHA"
+              ;;
+            *)
+              echo "unsupported event: $EVENT_NAME" >&2
               exit 1
-            fi
-            commit_sha=$(printf '%s' "$commit_sha" | tr '[:upper:]' '[:lower:]')
+              ;;
+          esac
 
+          if [[ ! "$commit_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+          commit_sha=$(printf '%s' "$commit_sha" | tr '[:upper:]' '[:lower:]')
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             if ! git ls-remote "https://github.com/${REPOSITORY}.git" 'refs/heads/*' |
               awk -v sha="$commit_sha" '$1 == sha { found = 1 } END { exit !found }'; then
               echo "commit_sha must be the current tip of a branch in ${REPOSITORY}" >&2
@@ -74,7 +88,17 @@ jobs:
       RAWDB_API_KEY_REQUIRED: "true"
       RAYON_NUM_THREADS: 4
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      # This opt-out is limited to a PR revision approved through builddrone.
+      - name: Checkout reviewed pull request
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+      - name: Checkout trusted revision
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
           persist-credentials: false


### PR DESCRIPTION
## Problem

GitHub's `actions/checkout` v4.4.0 hardening exposed two problems in the current combined workflow:

1. The RawDB job can no longer check out a fork head from `pull_request_target` without an explicit security opt-out, so #810 fails before its tests start.
2. The ordinary GitHub-hosted jobs also run from `pull_request_target`; with their default checkout, they test the upstream default branch instead of the pull request.

## Changes

- Run the ordinary test and build matrix on `pull_request` with a read-only `GITHUB_TOKEN`. These jobs now test the PR merge commit and receive no repository secrets.
- Move RawDB validation to `.github/workflows/rawdb.yaml`, whose `pull_request_target` definition is loaded from trusted `main`.
- Resolve the immutable PR head SHA on a GitHub-hosted runner, then wait for the existing `builddrone` approval before using `testdata-avail`.
- Enable checkout v4.4.0's `allow-unsafe-pr-checkout` only for that approved PR path.
- Preserve RawDB validation for pushes to `main` and manual validation of a reviewed upstream branch-tip SHA.
- Pin actions used on the self-hosted runner to full commit SHAs and disable persisted checkout credentials.

## Approval and trust boundary

The existing `builddrone` approval remains the primary gate. Approving the RawDB job is deliberately a decision to trust that exact PR revision: its build scripts and tests can access the RawDB secret and self-hosted runner.

As optional additional hardening, the `testdata-avail` runner group can be restricted to:

```
dnglab/dnglab/.github/workflows/rawdb.yaml@refs/heads/main
```

This runner-group setting is not required for the functional fix.

## Event behavior

| Event | Ordinary CI | RawDB |
| --- | --- | --- |
| Fork pull request | Tests the PR merge commit after normal fork-workflow approval | Tests the immutable PR head after `builddrone` approval |
| Push to `main` | Runs | Runs without the unsafe-checkout opt-out |
| Manual CI dispatch | Runs the selected repository ref | Not triggered |
| Manual RawDB dispatch from `main` | Not triggered | Accepts only a current `dnglab/dnglab` branch-tip SHA |

## Validation

- parsed every workflow with Ruby's YAML parser
- ran `actionlint` (allowing the repository-specific `testdata-avail` label)
- ran `git diff --check`
- verified PR, push, and manual SHA resolution paths
- verified manual dispatch rejects fork-only and short SHAs
- verified both privileged action pins
- ran `zizmor`; the only regular-persona finding is the expected `dangerous-triggers` warning for the reviewed `pull_request_target` opt-out

## Bootstrap note

Because `pull_request_target` loads its workflow from the default branch, #811 itself still shows the legacy RawDB job. Once this PR is merged, updating #810 will exercise the new gated pre-merge RawDB path.
