### PR TITLE
Fix DNG magenta cast when BlackLevelDelta tags are used

### DIFF
--- a/rawler/src/decoders/dng.rs
+++ b/rawler/src/decoders/dng.rs
@@ -3,6 +3,7 @@ use crate::cfa::*;
 use crate::decoders::*;
 use crate::formats::tiff::Entry;
 use crate::formats::tiff::Rational;
+use crate::formats::tiff::SRational;
 use crate::formats::tiff::Value;
 use crate::imgop::Dim2;
 use crate::imgop::Point;
@@ -31,6 +32,73 @@ pub struct DngFormat {
   tiff: GenericTiffReader,
 }
 
+fn active_area_borders(raw: &IFD) -> Option<[usize; 4]> {
+  raw
+    .get_entry(DngTag::ActiveArea)
+    .map(|crops| [crops.force_usize(0), crops.force_usize(1), crops.force_usize(2), crops.force_usize(3)])
+}
+
+fn get_blacklevel_delta(raw: &IFD, tag: DngTag, expected_count: usize, name: &str) -> Result<Vec<SRational>> {
+  if let Some(entry) = raw.get_entry(tag) {
+    if let Value::SRational(values) = &entry.value {
+      if values.len() == expected_count {
+        Ok(values.clone())
+      } else {
+        log::warn!("File has {} tag with invalid length: {}, expected: {}", name, values.len(), expected_count);
+        Ok(Vec::new())
+      }
+    } else {
+      Err(format!("Unsupported {} type: {}", name, entry.value_type_name()).into())
+    }
+  } else {
+    Ok(Vec::new())
+  }
+}
+
+fn get_blacklevels(raw: &IFD) -> Result<Option<BlackLevel>> {
+  let cpp = raw.get_entry(TiffCommonTag::SamplesPerPixel).map(|entry| entry.force_usize(0)).unwrap_or(1);
+  let base_entry = raw.get_entry(TiffCommonTag::BlackLevels);
+  let mut blacklevel = if let Some(entry) = base_entry {
+    let levels = match &entry.value {
+      Value::Short(black) => black.iter().copied().map(Rational::from).collect(),
+      Value::Long(black) => black.iter().copied().map(Rational::from).collect(),
+      Value::Rational(black) => black.clone(),
+      _ => return Err(format!("Unsupported BlackLevel type: {}", entry.value_type_name()).into()),
+    };
+    let mut repeat = (1, 1);
+    if let Some(Entry {
+      value: Value::Short(value), ..
+    }) = raw.get_entry(DngTag::BlackLevelRepeatDim)
+    {
+      if value.len() == 2 {
+        repeat = (value[0] as usize, value[1] as usize);
+      } else {
+        // Pentax K-3 Mark III Monochrome is known to have an invalid tag.
+        log::warn!("File has BlackLevelRepeatDim tag but with invalid length: {}", value.len());
+      }
+    }
+    BlackLevel::new(&levels, repeat.1, repeat.0, cpp)
+  } else {
+    BlackLevel::zero(1, 1, cpp)
+  };
+
+  let width = fetch_tiff_tag!(raw, TiffCommonTag::ImageWidth).force_usize(0);
+  let height = fetch_tiff_tag!(raw, TiffCommonTag::ImageLength).force_usize(0);
+  let [top, left, bottom, right] = active_area_borders(raw).unwrap_or([0, 0, height, width]);
+  if bottom < top || right < left || bottom > height || right > width {
+    return Err(format!("Invalid ActiveArea: [{}, {}, {}, {}]", top, left, bottom, right).into());
+  }
+
+  blacklevel.delta_h = get_blacklevel_delta(raw, DngTag::BlackLevelDeltaH, right - left, "BlackLevelDeltaH")?;
+  blacklevel.delta_v = get_blacklevel_delta(raw, DngTag::BlackLevelDeltaV, bottom - top, "BlackLevelDeltaV")?;
+
+  if base_entry.is_none() && !blacklevel.has_deltas() {
+    Ok(None)
+  } else {
+    Ok(Some(blacklevel))
+  }
+}
+
 impl<'a> Decoder for DngDecoder<'a> {
   fn raw_image(&self, file: &RawSource, _params: &RawDecodeParams, dummy: bool) -> Result<RawImage> {
     let raw = self.get_raw_ifd()?;
@@ -56,7 +124,7 @@ impl<'a> Decoder for DngDecoder<'a> {
       // panic!("Camera {} / {} is not in the camera catalog", cam.make, cam.model);
     }
 
-    let blacklevel = self.get_blacklevels(raw)?;
+    let blacklevel = get_blacklevels(raw)?;
     let whitelevel = self.get_whitelevels(raw)?.or(Some(WhiteLevel::new_bits(bits, cpp)));
 
     let photometric = match fetch_tiff_tag!(raw, TiffCommonTag::PhotometricInt).force_u32(0) {
@@ -306,33 +374,6 @@ impl<'a> DngDecoder<'a> {
     }
   }
 
-  fn get_blacklevels(&self, raw: &IFD) -> Result<Option<BlackLevel>> {
-    let cpp = raw.get_entry(TiffCommonTag::SamplesPerPixel).map(|entry| entry.force_usize(0)).unwrap_or(1);
-    if let Some(entry) = raw.get_entry(TiffCommonTag::BlackLevels) {
-      let levels = match &entry.value {
-        Value::Short(black) => black.iter().copied().map(Rational::from).collect(),
-        Value::Long(black) => black.iter().copied().map(Rational::from).collect(),
-        Value::Rational(black) => black.clone(),
-        _ => return Err(format!("Unsupported BlackLevel type: {}", entry.value_type_name()).into()),
-      };
-      let mut repeat = (1, 1);
-      if let Some(Entry {
-        value: Value::Short(value), ..
-      }) = raw.get_entry(DngTag::BlackLevelRepeatDim)
-      {
-        if value.len() == 2 {
-          repeat = (value[0] as usize, value[1] as usize);
-        } else {
-          // Pentax K-3 Mark III Monochrome is known to has invalid tag
-          log::warn!("File has BlackLevelRepeatDim tag but with invalid length: {}", value.len());
-        }
-      }
-      Ok(Some(BlackLevel::new(&levels, repeat.1, repeat.0, cpp)))
-    } else {
-      Ok(None)
-    }
-  }
-
   fn get_whitelevels(&self, raw: &IFD) -> Result<Option<WhiteLevel>> {
     let cpp = fetch_tiff_tag!(raw, TiffCommonTag::SamplesPerPixel).force_usize(0);
     if let Some(levels) = raw.get_entry(TiffCommonTag::WhiteLevel) {
@@ -362,13 +403,8 @@ impl<'a> DngDecoder<'a> {
   }
 
   fn get_active_area_borders(&self, raw: &IFD) -> Option<[usize; 4]> {
-    if let Some(crops) = raw.get_entry(DngTag::ActiveArea) {
-      let rect = [crops.force_usize(0), crops.force_usize(1), crops.force_usize(2), crops.force_usize(3)];
-      Some(rect)
-    } else {
-      // Ignore missing crops, at least some pentax DNGs don't have it
-      None
-    }
+    // Ignore missing crops, at least some Pentax DNGs don't have it.
+    active_area_borders(raw)
   }
 
   fn get_active_area(&self, raw: &IFD, width: usize, height: usize) -> Option<[usize; 4]> {
@@ -432,5 +468,64 @@ impl<'a> DngDecoder<'a> {
     // TODO: add 3
 
     Ok(result)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn add_entry(ifd: &mut IFD, tag: u16, value: Value) {
+    ifd.entries.insert(tag, Entry { tag, value, embedded: None });
+  }
+
+  #[test]
+  fn reads_blacklevel_deltas_relative_to_active_area() {
+    let mut raw = IFD::default();
+    add_entry(&mut raw, TiffCommonTag::ImageWidth.into(), Value::Long(vec![5]));
+    add_entry(&mut raw, TiffCommonTag::ImageLength.into(), Value::Long(vec![4]));
+    add_entry(&mut raw, TiffCommonTag::SamplesPerPixel.into(), Value::Short(vec![1]));
+    add_entry(&mut raw, DngTag::ActiveArea.into(), Value::Long(vec![1, 1, 3, 4]));
+    add_entry(&mut raw, DngTag::BlackLevel.into(), Value::Short(vec![10]));
+    add_entry(&mut raw, DngTag::BlackLevelRepeatDim.into(), Value::Short(vec![1, 1]));
+    add_entry(
+      &mut raw,
+      DngTag::BlackLevelDeltaH.into(),
+      Value::SRational(vec![SRational::new(1, 2), SRational::new(-1, 2), SRational::new(2, 1)]),
+    );
+    add_entry(
+      &mut raw,
+      DngTag::BlackLevelDeltaV.into(),
+      Value::SRational(vec![SRational::new(3, 1), SRational::new(-2, 1)]),
+    );
+
+    let blacklevel = get_blacklevels(&raw)
+      .expect("black-level tags should parse")
+      .expect("black-level metadata should be present");
+
+    assert_eq!(blacklevel.levels, vec![Rational::new(10, 1)]);
+    assert_eq!(blacklevel.delta_h.len(), 3);
+    assert_eq!(blacklevel.delta_h[1], SRational::new(-1, 2));
+    assert_eq!(blacklevel.delta_v, vec![SRational::new(3, 1), SRational::new(-2, 1)]);
+  }
+
+  #[test]
+  fn uses_default_blacklevel_when_only_delta_is_present() {
+    let mut raw = IFD::default();
+    add_entry(&mut raw, TiffCommonTag::ImageWidth.into(), Value::Long(vec![2]));
+    add_entry(&mut raw, TiffCommonTag::ImageLength.into(), Value::Long(vec![2]));
+    add_entry(&mut raw, TiffCommonTag::SamplesPerPixel.into(), Value::Short(vec![1]));
+    add_entry(
+      &mut raw,
+      DngTag::BlackLevelDeltaV.into(),
+      Value::SRational(vec![SRational::new(5, 1), SRational::new(6, 1)]),
+    );
+
+    let blacklevel = get_blacklevels(&raw)
+      .expect("black-level tags should parse")
+      .expect("delta metadata should create a black level");
+
+    assert_eq!(blacklevel.levels, vec![Rational::new(0, 1)]);
+    assert_eq!(blacklevel.delta_v, vec![SRational::new(5, 1), SRational::new(6, 1)]);
   }
 }

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -266,6 +266,26 @@ where
       self.ifd_mut().add_tag(DngTag::BlackLevel, blacklevel.levels.as_slice());
     }
 
+    if blacklevel.delta_h.len() == active_area.d.w {
+      self.ifd_mut().add_tag(DngTag::BlackLevelDeltaH, blacklevel.delta_h.as_slice());
+    } else if !blacklevel.delta_h.is_empty() {
+      log::warn!(
+        "Skipping BlackLevelDeltaH with length {}, expected {} for the output active area",
+        blacklevel.delta_h.len(),
+        active_area.d.w
+      );
+    }
+
+    if blacklevel.delta_v.len() == active_area.d.h {
+      self.ifd_mut().add_tag(DngTag::BlackLevelDeltaV, blacklevel.delta_v.as_slice());
+    } else if !blacklevel.delta_v.is_empty() {
+      log::warn!(
+        "Skipping BlackLevelDeltaV with length {}, expected {} for the output active area",
+        blacklevel.delta_v.len(),
+        active_area.d.h
+      );
+    }
+
     if !rawimage.blackareas.is_empty() {
       let data: Vec<u16> = rawimage.blackareas.iter().flat_map(rect_to_dng_area).collect();
       self.ifd_mut().add_tag(DngTag::MaskedAreas, &data);

--- a/rawler/src/imgop/raw.rs
+++ b/rawler/src/imgop/raw.rs
@@ -155,6 +155,100 @@ pub fn correct_blacklevel(raw: &mut [f32], blacklevel: &[f32], whitelevel: &[f32
   }
 }
 
+/// Correct raw data using a repeating black level plus DNG per-column and per-row deltas.
+///
+/// DNG black-level patterns and delta tables are relative to the top-left corner of the
+/// active area. Normalization uses the maximum computed black level for each sample plane.
+pub(crate) fn correct_blacklevel_with_deltas(
+  raw: &mut [f32],
+  width: usize,
+  height: usize,
+  cpp: usize,
+  blacklevel: &BlackLevel,
+  whitelevel: &[f32],
+  active_area: Rect,
+) {
+  assert_eq!(raw.len(), width * height * cpp);
+  assert_eq!(blacklevel.cpp, cpp);
+  assert_eq!(whitelevel.len(), cpp);
+  assert!(active_area.d.w > 0 && active_area.d.h > 0);
+  assert!(active_area.p.x + active_area.d.w <= width);
+  assert!(active_area.p.y + active_area.d.h <= height);
+  assert!(blacklevel.delta_h.is_empty() || blacklevel.delta_h.len() == active_area.d.w);
+  assert!(blacklevel.delta_v.is_empty() || blacklevel.delta_v.len() == active_area.d.h);
+
+  let delta_h: Vec<f32> = if blacklevel.delta_h.is_empty() {
+    vec![0.0; active_area.d.w]
+  } else {
+    blacklevel.delta_h.iter().map(|value| value.n as f32 / value.d as f32).collect()
+  };
+  let delta_v: Vec<f32> = if blacklevel.delta_v.is_empty() {
+    vec![0.0; active_area.d.h]
+  } else {
+    blacklevel.delta_v.iter().map(|value| value.n as f32 / value.d as f32).collect()
+  };
+
+  let mut max_delta_h = vec![f32::NEG_INFINITY; blacklevel.width];
+  for (column, delta) in delta_h.iter().enumerate() {
+    max_delta_h[column % blacklevel.width] = max_delta_h[column % blacklevel.width].max(*delta);
+  }
+
+  let mut max_delta_v = vec![f32::NEG_INFINITY; blacklevel.height];
+  for (row, delta) in delta_v.iter().enumerate() {
+    max_delta_v[row % blacklevel.height] = max_delta_v[row % blacklevel.height].max(*delta);
+  }
+
+  let mut maximum_blacklevel = vec![f32::NEG_INFINITY; cpp];
+  for (pattern_row, row_delta) in max_delta_v.iter().enumerate() {
+    if !row_delta.is_finite() {
+      continue;
+    }
+    for (pattern_column, column_delta) in max_delta_h.iter().enumerate() {
+      if !column_delta.is_finite() {
+        continue;
+      }
+      for (sample, maximum) in maximum_blacklevel.iter_mut().enumerate() {
+        let index = (pattern_row * blacklevel.width + pattern_column) * cpp + sample;
+        *maximum = maximum.max(blacklevel.levels[index].as_f32() + column_delta + row_delta);
+      }
+    }
+  }
+
+  let scale: Vec<f32> = whitelevel
+    .iter()
+    .zip(maximum_blacklevel.iter())
+    .map(|(white, black)| 1.0 / (white - black))
+    .collect();
+  let active_right = active_area.p.x + active_area.d.w;
+  let active_bottom = active_area.p.y + active_area.d.h;
+  let pattern_origin_x = active_area.p.x % blacklevel.width;
+  let pattern_origin_y = active_area.p.y % blacklevel.height;
+
+  raw.par_chunks_exact_mut(width * cpp).enumerate().for_each(|(row, line)| {
+    let pattern_row = (row + blacklevel.height - pattern_origin_y) % blacklevel.height;
+    let row_delta = if row >= active_area.p.y && row < active_bottom {
+      delta_v[row - active_area.p.y]
+    } else {
+      0.0
+    };
+
+    line.chunks_exact_mut(cpp).enumerate().for_each(|(column, pixel)| {
+      let pattern_column = (column + blacklevel.width - pattern_origin_x) % blacklevel.width;
+      let column_delta = if column >= active_area.p.x && column < active_right {
+        delta_h[column - active_area.p.x]
+      } else {
+        0.0
+      };
+
+      for sample in 0..cpp {
+        let index = (pattern_row * blacklevel.width + pattern_column) * cpp + sample;
+        let black = blacklevel.levels[index].as_f32() + column_delta + row_delta;
+        pixel[sample] = (pixel[sample] - black).max(0.0) * scale[sample];
+      }
+    });
+  });
+}
+
 /// Correct data by blacklevel and whitelevel on CFA (bayer) data.
 ///
 /// The output is between 0.0 .. 1.0.
@@ -187,6 +281,65 @@ pub fn correct_blacklevel_cfa(raw: &mut [f32], width: usize, _height: usize, bla
       b[1] = clip(b[1] - blacklevel[3]) / max[3];
     });
   });
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::formats::tiff::SRational;
+  use approx::assert_abs_diff_eq;
+
+  #[test]
+  fn corrects_signed_dng_blacklevel_deltas() {
+    let mut blacklevel = BlackLevel::new(&[10_u16], 1, 1, 1);
+    blacklevel.delta_h = vec![SRational::new(0, 1), SRational::new(1, 1), SRational::new(2, 1)];
+    blacklevel.delta_v = vec![SRational::new(-1, 1), SRational::new(3, 1)];
+
+    let mut raw = vec![9.0, 10.0, 11.0, 13.0, 56.5, 100.0];
+    correct_blacklevel_with_deltas(
+      &mut raw,
+      3,
+      2,
+      1,
+      &blacklevel,
+      &[100.0],
+      Rect::new(crate::imgop::Point::zero(), crate::imgop::Dim2::new(3, 2)),
+    );
+
+    assert_abs_diff_eq!(raw[0], 0.0);
+    assert_abs_diff_eq!(raw[1], 0.0);
+    assert_abs_diff_eq!(raw[2], 0.0);
+    assert_abs_diff_eq!(raw[3], 0.0);
+    assert_abs_diff_eq!(raw[4], 0.5, epsilon = 1e-6);
+    assert_abs_diff_eq!(raw[5], 1.0, epsilon = 1e-6);
+  }
+
+  #[test]
+  fn anchors_dng_blacklevel_pattern_to_active_area() {
+    let mut blacklevel = BlackLevel::new(&[10_u16, 20, 30, 40], 2, 2, 1);
+    blacklevel.delta_h = vec![SRational::new(0, 1); 2];
+    blacklevel.delta_v = vec![SRational::new(0, 1); 2];
+
+    let mut raw = vec![0.0; 16];
+    raw[5] = 10.0;
+    raw[6] = 20.0;
+    raw[9] = 30.0;
+    raw[10] = 100.0;
+    correct_blacklevel_with_deltas(
+      &mut raw,
+      4,
+      4,
+      1,
+      &blacklevel,
+      &[100.0],
+      Rect::new(crate::imgop::Point::new(1, 1), crate::imgop::Dim2::new(2, 2)),
+    );
+
+    assert_abs_diff_eq!(raw[5], 0.0);
+    assert_abs_diff_eq!(raw[6], 0.0);
+    assert_abs_diff_eq!(raw[9], 0.0);
+    assert_abs_diff_eq!(raw[10], 1.0, epsilon = 1e-6);
+  }
 }
 
 #[multiversion(targets("x86_64+avx+avx2", "x86+sse", "aarch64+neon"))]

--- a/rawler/src/rawimage.rs
+++ b/rawler/src/rawimage.rs
@@ -9,14 +9,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::cfa::PlaneColor;
-use crate::imgop::raw::{correct_blacklevel, correct_blacklevel_cfa};
+use crate::imgop::raw::{correct_blacklevel, correct_blacklevel_cfa, correct_blacklevel_with_deltas};
 use crate::imgop::sensor::SensorType;
 use crate::imgop::{convert_from_f32_scaled_u16, convert_to_f32_unscaled};
 use crate::pixarray::SubPixel;
 use crate::{
   CFA,
   decoders::*,
-  formats::tiff::{Rational, Value},
+  formats::tiff::{Rational, SRational, Value},
   imgop::{
     Dim2, Point, Rect,
     raw::{ColorMatrix, DevelopParams},
@@ -67,6 +67,10 @@ pub struct BlackLevel {
   pub cpp: usize,
   pub width: usize,
   pub height: usize,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub delta_h: Vec<SRational>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub delta_v: Vec<SRational>,
 }
 
 impl Default for BlackLevel {
@@ -76,6 +80,8 @@ impl Default for BlackLevel {
       width: 1,
       height: 1,
       cpp: 1,
+      delta_h: Vec::new(),
+      delta_v: Vec::new(),
     }
   }
 }
@@ -83,7 +89,15 @@ impl Default for BlackLevel {
 impl std::fmt::Debug for BlackLevel {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     let levels: Vec<f32> = self.levels.iter().map(|x| x.as_f32()).collect();
-    f.write_fmt(format_args!("RepeatDim: {}:{}, cpp: {}, {:?}", self.height, self.width, self.cpp, levels))
+    f.write_fmt(format_args!(
+      "RepeatDim: {}:{}, cpp: {}, DeltaH: {}, DeltaV: {}, {:?}",
+      self.height,
+      self.width,
+      self.cpp,
+      self.delta_h.len(),
+      self.delta_v.len(),
+      levels
+    ))
   }
 }
 
@@ -98,6 +112,8 @@ impl BlackLevel {
       width,
       height,
       cpp,
+      delta_h: Vec::new(),
+      delta_v: Vec::new(),
     }
   }
 
@@ -113,6 +129,8 @@ impl BlackLevel {
       width,
       height,
       cpp,
+      delta_h: Vec::new(),
+      delta_v: Vec::new(),
     }
   }
 
@@ -140,6 +158,10 @@ impl BlackLevel {
 
   pub fn sample_count(&self) -> usize {
     self.cpp * self.width * self.height
+  }
+
+  pub fn has_deltas(&self) -> bool {
+    !self.delta_h.is_empty() || !self.delta_v.is_empty()
   }
 
   // TODO: write test
@@ -518,24 +540,42 @@ impl RawImage {
   /// Internal blacklevel and whitelevel is reset to 0.0 and 1.0 to match image data.
   pub fn apply_scaling(&mut self) -> crate::Result<()> {
     let mut pixels = self.data.as_f32();
-    match &self.photometric {
-      RawPhotometricInterpretation::BlackIsZero => todo!(),
-      RawPhotometricInterpretation::Cfa(_) => {
-        correct_blacklevel_cfa(
-          pixels.to_mut(),
-          self.width,
-          self.height,
-          &self.blacklevel.as_bayer_array(),
-          &self.whitelevel.as_bayer_array(),
-        );
-        self.data = RawImageData::Float(pixels.into_owned());
+    if self.blacklevel.has_deltas() {
+      match &self.photometric {
+        RawPhotometricInterpretation::BlackIsZero => todo!(),
+        RawPhotometricInterpretation::Cfa(_) | RawPhotometricInterpretation::LinearRaw => {
+          correct_blacklevel_with_deltas(
+            pixels.to_mut(),
+            self.width,
+            self.height,
+            self.cpp,
+            &self.blacklevel,
+            &self.whitelevel.as_vec(),
+            self.active_area.unwrap_or_else(|| Rect::new(Point::zero(), self.dim())),
+          );
+        }
       }
-      RawPhotometricInterpretation::LinearRaw => {
-        correct_blacklevel(pixels.to_mut(), &self.blacklevel.as_vec(), &self.whitelevel.as_vec());
-        self.data = RawImageData::Float(pixels.into_owned());
+    } else {
+      match &self.photometric {
+        RawPhotometricInterpretation::BlackIsZero => todo!(),
+        RawPhotometricInterpretation::Cfa(_) => {
+          correct_blacklevel_cfa(
+            pixels.to_mut(),
+            self.width,
+            self.height,
+            &self.blacklevel.as_bayer_array(),
+            &self.whitelevel.as_bayer_array(),
+          );
+        }
+        RawPhotometricInterpretation::LinearRaw => {
+          correct_blacklevel(pixels.to_mut(), &self.blacklevel.as_vec(), &self.whitelevel.as_vec());
+        }
       }
     }
+    self.data = RawImageData::Float(pixels.into_owned());
     self.blacklevel.levels.iter_mut().for_each(|x| *x = Rational::new(0, 1));
+    self.blacklevel.delta_h.clear();
+    self.blacklevel.delta_v.clear();
     self.whitelevel.0.iter_mut().for_each(|x| *x = 1);
     Ok(())
   }


### PR DESCRIPTION
## Problem

Fixes #820.

Some DNG files develop with a strong magenta cast. The affected files are those that store some or all of their effective black level in `BlackLevelDeltaH` or `BlackLevelDeltaV` rather than entirely in the base `BlackLevel` tag.

For example, the affected `DNG` has `BlackLevel: 0` and 2,602 `BlackLevelDeltaV` values. In contrast, unaffected `DNG` stores its complete black offset directly as a 2×2 `BlackLevel` of 1024 and already renders correctly.

## Root cause

The DNG decoder read `BlackLevel` and `BlackLevelRepeatDim`, but ignored the horizontal and vertical black-level delta tables. This left an approximately 256-count pedestal in `IMG_8077.dng`. White balance then amplified the residual channel values into the visible magenta cast.

The DNG specification defines the per-pixel black level as the sum of the repeating base level, the horizontal delta, and the vertical delta. It also requires normalization to use `WhiteLevel - maximum computed black level` for each sample plane.

Specification: https://helpx.adobe.com/content/dam/help/en/camera-raw/digital-negative/jcr_content/root/content/flex/items/position/position-par/download_section_733958301/download-1/DNG_Spec_1_7_1_0.pdf

## Solution

- parse signed `BlackLevelDeltaH` and `BlackLevelDeltaV` values from DNG raw IFDs
- validate delta-table lengths against the `ActiveArea`
- compute each pixel's black level from the repeating base plus its row and column deltas, using the `ActiveArea` as the coordinate origin
- normalize each sample plane using its maximum computed black level
- preserve valid delta tables when writing DNG files
- retain the existing fast path for files without delta tables


The private sample DNGs are not included in the repository, but I can provide if needed.
