### PR TITLE
Fix OriginalRawFileDigest handling

### DIFF
--- a/bin/dnglab/dnglab-lib/src/jobs/extractraw.rs
+++ b/bin/dnglab/dnglab-lib/src/jobs/extractraw.rs
@@ -5,15 +5,11 @@ use super::Job;
 use crate::{AppError, Result};
 use async_trait::async_trait;
 use log::debug;
-use rawler::{
-  dng::original::{OriginalCompressed, OriginalDigest},
-  formats::tiff::{GenericTiffReader, Value, reader::TiffReader},
-  tags::DngTag,
-};
+use rawler::{dng::original::extract_original, rawsource::RawSource};
 use std::{
   fmt::Display,
   fs::remove_file,
-  io::{BufReader, BufWriter, Cursor, Write},
+  io::{BufWriter, Write},
 };
 use std::{fs::File, path::PathBuf, time::Instant};
 
@@ -56,43 +52,22 @@ impl ExtractRawJob {
     if self.output.exists() && !self.replace {
       return Err(AppError::AlreadyExists(self.output.clone()));
     }
-    let dng_file = File::open(&self.input)?;
-
-    let mut in_file = BufReader::new(dng_file);
-    let file = GenericTiffReader::new(&mut in_file, 0, 0, None, &[]).map_err(|e| AppError::General(e.to_string()))?;
-
-    if !file.has_entry(DngTag::DNGVersion) {
-      debug!("Input is not a DNG file");
-      return Err(AppError::General("Input file is not a DNG".into()));
-    }
-    if let Some(orig_data) = file.get_entry(DngTag::OriginalRawFileData) {
-      if let Value::Undefined(val) = &orig_data.value {
-        let digest = file
-          .get_entry(DngTag::OriginalRawFileDigest)
-          .map(|entry| entry.value.get_data().as_slice())
-          .and_then(|data| OriginalDigest::try_from(data).ok());
-
-        let original = OriginalCompressed::new(&mut Cursor::new(val), digest)?;
-        let mut stream = BufWriter::new(File::create(&self.output)?);
-        if let Err(err) = original.decompress(&mut stream, !self.skip_checks) {
-          drop(original);
-          if let Err(err) = remove_file(&self.output) {
-            log::error!("Failed to delete original file after decompress error: {:?}", err);
-          }
-          return Err(err.into());
-        }
-        stream.flush()?;
-        Ok(JobResult {
-          job: self.clone(),
-          duration: 0.0, // TODO: fixme
-          error: None,
-        })
-      } else {
-        Err(AppError::General("No embedded raw data found".into()))
+    let dng = RawSource::new(&self.input)?;
+    let mut target = BufWriter::new(File::create(&self.output)?);
+    if let Err(err) = extract_original(&dng, &mut target, !self.skip_checks) {
+      drop(target);
+      if let Err(err) = remove_file(&self.output) {
+        log::error!("Failed to delete original file after decompress error: {:?}", err);
       }
-    } else {
-      Err(AppError::General("No embedded raw file found".into()))
+      return Err(err.into());
     }
+    target.flush()?;
+    drop(target);
+    Ok(JobResult {
+      job: self.clone(),
+      duration: 0.0, // Overwritten with the measured elapsed time in `execute`.
+      error: None,
+    })
   }
 }
 

--- a/rawler/src/dng/convert.rs
+++ b/rawler/src/dng/convert.rs
@@ -73,6 +73,80 @@ impl Default for ConvertParams {
   }
 }
 
+impl ConvertParams {
+  /// Set whether the original raw file is embedded into the DNG.
+  pub fn with_embedded(mut self, embedded: bool) -> Self {
+    self.embedded = embedded;
+    self
+  }
+
+  /// Set the DNG compression method.
+  pub fn with_compression(mut self, compression: DngCompression) -> Self {
+    self.compression = compression;
+    self
+  }
+
+  /// Set the photometric conversion mode.
+  pub fn with_photometric_conversion(mut self, photometric_conversion: DngPhotometricConversion) -> Self {
+    self.photometric_conversion = photometric_conversion;
+    self
+  }
+
+  /// Set whether black/white level scaling is applied.
+  pub fn with_apply_scaling(mut self, apply_scaling: bool) -> Self {
+    self.apply_scaling = apply_scaling;
+    self
+  }
+
+  /// Set the crop mode.
+  pub fn with_crop(mut self, crop: CropMode) -> Self {
+    self.crop = crop;
+    self
+  }
+
+  /// Set the compression predictor.
+  pub fn with_predictor(mut self, predictor: u8) -> Self {
+    self.predictor = predictor;
+    self
+  }
+
+  /// Set whether a preview image is generated.
+  pub fn with_preview(mut self, preview: bool) -> Self {
+    self.preview = preview;
+    self
+  }
+
+  /// Set whether a thumbnail image is generated.
+  pub fn with_thumbnail(mut self, thumbnail: bool) -> Self {
+    self.thumbnail = thumbnail;
+    self
+  }
+
+  /// Set the artist metadata field.
+  pub fn with_artist(mut self, artist: Option<String>) -> Self {
+    self.artist = artist;
+    self
+  }
+
+  /// Set the software metadata field.
+  pub fn with_software(mut self, software: String) -> Self {
+    self.software = software;
+    self
+  }
+
+  /// Set the image index to convert.
+  pub fn with_index(mut self, index: usize) -> Self {
+    self.index = index;
+    self
+  }
+
+  /// Set whether the source modification time is preserved.
+  pub fn with_keep_mtime(mut self, keep_mtime: bool) -> Self {
+    self.keep_mtime = keep_mtime;
+    self
+  }
+}
+
 /// Convert a raw input file into DNG
 ///
 /// We don't accept a DNG file path here, because we don't know

--- a/rawler/src/dng/original.rs
+++ b/rawler/src/dng/original.rs
@@ -6,9 +6,16 @@ use libflate::zlib::{Decoder, EncodeOptions, Encoder};
 use log::debug;
 use rayon::prelude::*;
 use std::{
-  io::{self, Read, Seek, SeekFrom, Write},
+  io::{self, Cursor, Read, Seek, SeekFrom, Write},
   mem::size_of,
   ops::Neg,
+};
+
+use crate::{
+  RawlerError,
+  formats::tiff::{GenericTiffReader, Value, reader::TiffReader},
+  rawsource::RawSource,
+  tags::DngTag,
 };
 
 // DNG requires this block size
@@ -19,11 +26,10 @@ pub type OriginalDigest = [u8; 16];
 pub struct OriginalCompressed {
   raw_fork_size: u32,
   chunks: Vec<ForkBlock>,
-  digest: Option<OriginalDigest>,
 }
 
 impl OriginalCompressed {
-  pub fn new<T>(stream: &mut T, digest: Option<OriginalDigest>) -> io::Result<Self>
+  pub fn new<T>(stream: &mut T) -> io::Result<Self>
   where
     T: Read + Seek,
   {
@@ -55,37 +61,18 @@ impl OriginalCompressed {
       }
     }
 
-    Ok(Self { chunks, raw_fork_size, digest })
+    Ok(Self { chunks, raw_fork_size })
   }
 
-  pub fn decompress<T>(&self, stream: &mut T, verify_digest: bool) -> io::Result<usize>
+  pub fn decompress<T>(&self, stream: &mut T) -> io::Result<usize>
   where
     T: Write,
   {
-    let mut ctx = md5::Context::new();
-
     let mut total = 0;
     for chunk in self.chunks.iter().map(ForkBlock::decompress) {
       let buf = chunk?;
       stream.write_all(&buf)?;
-      total = buf.len();
-      ctx.consume(&buf);
-    }
-
-    let new_digest = ctx.finalize().into();
-
-    debug!("Encoded calculated original data digest: {:x?}", self.digest);
-    debug!("New calculated original data digest: {:x?}", new_digest);
-
-    if self.digest.ne(&Some(new_digest)) {
-      if verify_digest {
-        return Err(io::Error::new(
-          io::ErrorKind::InvalidData,
-          "Embedded original digest and output digest mismatch, data may be corrupt",
-        ));
-      } else {
-        log::warn!("Embedded original digest and output digest mismatch, data may be corrupt, but verify checks are disabled");
-      }
+      total += buf.len();
     }
     Ok(total)
   }
@@ -105,33 +92,28 @@ impl OriginalCompressed {
     let raw_fork_blocks = raw_fork_size.div_ceil(COMPRESS_BLOCK_SIZE); // (raw_fork_size + (COMPRESS_BLOCK_SIZE - 1)) / COMPRESS_BLOCK_SIZE
     let mut forks = Vec::with_capacity(raw_fork_blocks as usize);
 
-    let mut ctx = md5::Context::new();
-
     loop {
       let mut buf = Vec::with_capacity(COMPRESS_BLOCK_SIZE as usize);
       stream.take(COMPRESS_BLOCK_SIZE as u64).read_to_end(&mut buf)?;
       if buf.is_empty() {
         break;
       }
-      ctx.consume(&buf);
       forks.push(buf);
       //chunks.push(ForkBlock::compress(&buf)?);
     }
     let chunks = forks.par_iter().flat_map(ForkBlock::compress).collect();
-    let digest = Some(ctx.finalize().into());
-
-    Ok(Self { raw_fork_size, chunks, digest })
-  }
-
-  pub fn digest(&self) -> Option<OriginalDigest> {
-    self.digest
+    Ok(Self { raw_fork_size, chunks })
   }
 
   /// Write compressed chunks to output stream.
-  pub fn write_to_stream<T>(&self, stream: &mut T) -> io::Result<()>
+  ///
+  /// Returns the MD5 digest of everything written to `stream`.
+  pub fn write_to_stream<T>(&self, stream: &mut T) -> io::Result<md5::Digest>
   where
     T: Write,
   {
+    // Tee every byte into the digest as it is written to the stream.
+    let mut stream = DigestWriter::new(stream);
     stream.write_all(&self.raw_fork_size.to_be_bytes())?; // Fork 1
     let chunks_start: u32 = (size_of::<u32>() + (self.chunks.len() + 1) * size_of::<u32>()) as u32;
     // Offset of first chunk
@@ -153,7 +135,101 @@ impl OriginalCompressed {
     stream.write_all(&0u32.to_be_bytes())?;
     stream.write_all(&0u32.to_be_bytes())?;
     stream.write_all(&0u32.to_be_bytes())?;
-    Ok(())
+    Ok(stream.finalize())
+  }
+}
+
+/// A [`Write`] adapter that forwards all bytes to an inner writer while
+/// feeding them into an MD5 context, so the digest of the written stream is
+/// available without a second pass over the data.
+struct DigestWriter<'a, T> {
+  inner: &'a mut T,
+  context: md5::Context,
+}
+
+impl<'a, T: Write> DigestWriter<'a, T> {
+  fn new(inner: &'a mut T) -> Self {
+    Self {
+      inner,
+      context: md5::Context::new(),
+    }
+  }
+
+  /// Consume the adapter and return the digest of everything written so far.
+  fn finalize(self) -> md5::Digest {
+    self.context.finalize()
+  }
+}
+
+impl<T: Write> Write for DigestWriter<'_, T> {
+  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    let written = self.inner.write(buf)?;
+    // Only hash the bytes actually accepted by the inner writer.
+    self.context.consume(&buf[..written]);
+    Ok(written)
+  }
+
+  fn flush(&mut self) -> io::Result<()> {
+    self.inner.flush()
+  }
+}
+
+/// Extract the original raw file embedded in a DNG and write it to `target`.
+///
+/// Reads the `OriginalRawFileData` tag from `dng`, decompresses the embedded
+/// payload and writes the reconstructed original file to `target`. When
+/// `verify_digest` is `true`, the decompressed data is checked against the
+/// `OriginalRawFileDigest` stored in the DNG.
+///
+/// Returns the number of bytes written to `target`.
+///
+/// # Errors
+///
+/// Fails if `dng` is not a valid DNG, does not embed an original raw file, or
+/// if digest verification fails.
+pub fn extract_original<W: Write + Seek + Send>(dng: &RawSource, target: &mut W, verify_digest: bool) -> crate::Result<usize> {
+  //let mut in_file = BufReader::new(dng_file);
+  let file = GenericTiffReader::new(&mut dng.reader(), 0, 0, None, &[])?;
+
+  if !file.has_entry(DngTag::DNGVersion) {
+    return Err(RawlerError::DecoderFailed(format!(
+      "Input file '{}' is not a valid DNG file",
+      dng.path().display()
+    )));
+  }
+  if let Some(orig_data) = file.get_entry(DngTag::OriginalRawFileData) {
+    if let Value::Undefined(val) = &orig_data.value {
+      let digest = file
+        .get_entry(DngTag::OriginalRawFileDigest)
+        .map(|entry| entry.value.get_data().as_slice())
+        .and_then(|data| OriginalDigest::try_from(data).ok());
+      let new_digest = md5::compute(val);
+
+      debug!("Encoded calculated original data digest: {:x?}", digest);
+      debug!("New calculated original data digest: {:x?}", new_digest);
+
+      if digest.ne(&Some(new_digest.into())) {
+        if verify_digest {
+          return Err(RawlerError::DecoderFailed(
+            "Embedded original digest and output digest mismatch, data may be corrupt".into(),
+          ));
+        } else {
+          log::warn!("Embedded original digest and output digest mismatch, data may be corrupt, but verify checks are disabled");
+        }
+      }
+
+      let original = OriginalCompressed::new(&mut Cursor::new(val))?;
+      match original.decompress(target) {
+        Ok(size) => Ok(size),
+        Err(error) => Err(RawlerError::with_io_error("extract_original", dng.path(), error)),
+      }
+    } else {
+      Err(RawlerError::DecoderFailed("DNG file contains OriginalRawFileData tag, but is invalid".into()))
+    }
+  } else {
+    Err(RawlerError::DecoderFailed(
+      "No embedded raw file found (missing OriginalRawFileData tag)".into(),
+    ))
   }
 }
 
@@ -206,19 +282,17 @@ mod tests {
     let mut file = Cursor::new(data);
     // Compress
     let orig = OriginalCompressed::compress(&mut file)?;
-    let digest = orig.digest;
     let mut out = Cursor::new(Vec::new());
-    orig.write_to_stream(&mut out)?;
+    let _digest = orig.write_to_stream(&mut out)?;
     out.seek(SeekFrom::Start(0))?;
     // Reload
-    let comp = OriginalCompressed::new(&mut out, digest)?;
+    let comp = OriginalCompressed::new(&mut out)?;
     // Decompress
     let mut restored = Cursor::new(Vec::new());
-    comp.decompress(&mut restored, true)?;
+    comp.decompress(&mut restored)?;
     // Compare
     let unpacked = restored.into_inner();
     assert_eq!(unpacked, data);
-    assert_eq!(digest, Some(md5::compute(&unpacked).into()));
     Ok(())
   }
 
@@ -228,19 +302,17 @@ mod tests {
     let mut file = Cursor::new(data);
     // Compress
     let orig = OriginalCompressed::compress(&mut file)?;
-    let digest = orig.digest;
     let mut out = Cursor::new(Vec::new());
-    orig.write_to_stream(&mut out)?;
+    let _digest = orig.write_to_stream(&mut out)?;
     out.seek(SeekFrom::Start(0))?;
     // Reload
-    let comp = OriginalCompressed::new(&mut out, digest)?;
+    let comp = OriginalCompressed::new(&mut out)?;
     // Decompress
     let mut restored = Cursor::new(Vec::new());
-    comp.decompress(&mut restored, true)?;
+    comp.decompress(&mut restored)?;
     // Compare
     let unpacked = restored.into_inner();
     assert_eq!(unpacked, data);
-    assert_eq!(digest, Some(md5::compute(&unpacked).into()));
     Ok(())
   }
 }

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -449,13 +449,11 @@ where
 
   pub fn original_file(&mut self, original: &OriginalCompressed, filename: impl AsRef<str>) -> Result<()> {
     let mut buf = std::io::Cursor::new(Vec::new());
-    original.write_to_stream(&mut buf)?;
+    let digest = original.write_to_stream(&mut buf)?;
 
     self.root_ifd.add_tag_undefined(DngTag::OriginalRawFileData, buf.into_inner());
     self.root_ifd.add_tag(DngTag::OriginalRawFileName, filename.as_ref());
-    if let Some(digest) = original.digest() {
-      self.root_ifd.add_tag(DngTag::OriginalRawFileDigest, digest);
-    }
+    self.root_ifd.add_tag(DngTag::OriginalRawFileDigest, <[u8; 16]>::from(digest));
     Ok(())
   }
 

--- a/rawler/tests/issues/mod.rs
+++ b/rawler/tests/issues/mod.rs
@@ -5,6 +5,7 @@ use rawler::devtools::rawdb::get_rawdb_cache;
 use rawler::devtools::rawdb::rawdb_ensure_file;
 use rawler::dng::convert::ConvertParams;
 use rawler::dng::convert::convert_raw_file;
+use rawler::dng::original::extract_original;
 use rawler::formats::jfif::Jfif;
 use rawler::rawsource::RawSource;
 use rawler::{analyze::raw_pixels_digest, decoders::RawDecodeParams};
@@ -69,5 +70,35 @@ fn dnglab_619_silverfast_scan_missing_illuminant() -> std::result::Result<(), Bo
   let path = rawdb_ensure_file(&get_rawdb_cache(), "dnglab", "dnglab-issue-619", "testfiles/silverfast_scan.dng")?;
   let mut dng = Cursor::new(Vec::new());
   convert_raw_file(&path, &mut dng, &ConvertParams::default())?;
+  Ok(())
+}
+
+#[test]
+fn dnglab_807_extract_embedded_raw_invalid_digest() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  let path = rawdb_ensure_file(&get_rawdb_cache(), "dnglab", "dnglab-issue-807", "testfiles/dnglab-issue-807_embedded_original.dng")?;
+  let mut original = Cursor::new(Vec::new());
+  let dng = RawSource::new(&path)?;
+  let verify_digest = true;
+  extract_original(&dng, &mut original, verify_digest)?;
+  let plain = original.into_inner();
+  let plain_digest = md5::compute(&plain);
+  assert_eq!(format!("{:x}", plain_digest), "a968cf0183a84c51ef492c631c6d16b7");
+  Ok(())
+}
+
+#[test]
+fn dnglab_807_digest_calculation() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  let path = rawdb_ensure_file(&get_rawdb_cache(), "Canon", "EOS 40D", "raw_modes/Canon EOS 40D_ISO_100_RAW.CR2")?;
+  let mut dng = Cursor::new(Vec::new());
+  convert_raw_file(&path, &mut dng, &ConvertParams::default().with_embedded(true))?;
+  // Now verify
+  let inner = dng.into_inner();
+  let mut original = Cursor::new(Vec::new());
+  let dng = RawSource::new_from_slice(&inner);
+  let verify_digest = true;
+  extract_original(&dng, &mut original, verify_digest)?;
+  let plain = original.into_inner();
+  let plain_digest = md5::compute(&plain);
+  assert_eq!(format!("{:x}", plain_digest), "a968cf0183a84c51ef492c631c6d16b7");
   Ok(())
 }


### PR DESCRIPTION
The tag must contain the digest for the OriginalRawFileData payload, not the original raw file.

fixes #807 