### PR TITLE
Fix panic with parallel tasks. Fixes Camera Roll previews. Fixes 200-800mm lens metadata.

### DIFF
--- a/bin/dnglab/dnglab-lib/src/convert.rs
+++ b/bin/dnglab/dnglab-lib/src/convert.rs
@@ -4,7 +4,7 @@
 use clap::ArgMatches;
 use futures::future::join_all;
 use rawler::decoders::supported_extensions;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 
@@ -63,8 +63,29 @@ pub async fn convert(options: &ArgMatches) -> crate::Result<()> {
   let concurrency = resolve_concurrency(options.get_one::<usize>("jobs").copied().unwrap_or(0));
 
   let mut results: Vec<JobResult> = Vec::new();
-  for chunks in jobs.chunks(concurrency) {
-    let mut temp: Vec<JobResult> = join_all(chunks.iter().map(|j| j.execute()))
+
+  // `--image-index all` expands one multi-image RAW into multiple jobs which
+  // all read the same source file. Do not execute two jobs for the same input
+  // concurrently. Jobs for different source files may still run concurrently
+  // up to `concurrency`, so directory/batch conversions retain outer
+  // parallelism.
+  let mut pending: VecDeque<Raw2DngJob> = jobs.into();
+  while !pending.is_empty() {
+    let mut batch: Vec<Raw2DngJob> = Vec::with_capacity(concurrency);
+    let mut deferred: VecDeque<Raw2DngJob> = VecDeque::new();
+    let mut active_inputs: HashSet<PathBuf> = HashSet::new();
+
+    while let Some(job) = pending.pop_front() {
+      if batch.len() < concurrency && active_inputs.insert(job.input.clone()) {
+        batch.push(job);
+      } else {
+        deferred.push_back(job);
+      }
+    }
+    pending = deferred;
+    debug_assert!(!batch.is_empty());
+
+    let mut temp: Vec<JobResult> = join_all(batch.iter().map(|j| j.execute()))
       .await
       .into_iter()
       .map(|res| {

--- a/bin/dnglab/dnglab-lib/src/jobs/raw2dng.rs
+++ b/bin/dnglab/dnglab-lib/src/jobs/raw2dng.rs
@@ -16,9 +16,11 @@ use std::{
   fmt::Display,
   fs::{File, remove_file},
   io::BufWriter,
+  panic::{AssertUnwindSafe, catch_unwind},
   time::SystemTime,
 };
 use std::{path::PathBuf, time::Instant};
+use tokio::task::spawn_blocking;
 
 /// Job for converting RAW to DNG
 #[derive(Debug, Clone)]
@@ -147,21 +149,41 @@ impl Job for Raw2DngJob {
     let now = Instant::now();
     let cp = self.clone();
 
-    // Run the CPU-bound conversion on rayon's global pool rather than tokio's
-    // blocking pool. Rationale:
-    //   - The work inside `internal_exec` already fans out through `par_iter`
-    //     on rayon for LJPEG tile compression. Dispatching the outer job onto
-    //     rayon too keeps every CPU thread under one work-stealing scheduler,
-    //     avoiding the "tokio-blocking-thread holds the call frame while
-    //     rayon does the work on different threads" double-dispatch.
-    //   - Tokio's blocking pool is sized for I/O fanout.
-    // A tokio oneshot bridges the result back into the async driver.
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    rayon::spawn(move || {
-      let _ = tx.send(cp.internal_exec());
+    // Keep the outer conversion job off Rayon's global pool. The conversion
+    // itself uses Rayon internally for CPU-parallel work such as LJPEG tile
+    // compression. Running the outer job as an unowned `rayon::spawn()` task
+    // means a panic propagated out of that conversion reaches the top of a
+    // Rayon spawn task; Rayon's default behavior for such an unhandled panic
+    // is to abort the process.
+    //
+    // `spawn_blocking` gives the conversion an owning Tokio JoinHandle.
+    // `catch_unwind` additionally turns a decoder/writer panic into a normal
+    // per-job error and lets us remove the partially written output file.
+    let handle = spawn_blocking(move || {
+      let output = cp.output.clone();
+      match catch_unwind(AssertUnwindSafe(|| cp.internal_exec())) {
+        Ok(result) => result,
+        Err(payload) => {
+          let message = if let Some(s) = payload.downcast_ref::<&str>() {
+            (*s).to_string()
+          } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+          } else {
+            "unknown panic payload".to_string()
+          };
+
+          if let Err(err) = remove_file(&output) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+              log::error!("Failed to delete DNG file after conversion panic: {:?}", err);
+            }
+          }
+
+          Err(AppError::General(format!("Conversion worker panicked: {message}")))
+        }
+      }
     });
 
-    match rx.await {
+    match handle.await {
       Ok(Ok(mut stat)) => {
         stat.duration = now.elapsed().as_secs_f32();
         eprintln!("Writing DNG output file: {}", stat.job.output.display());
@@ -172,10 +194,10 @@ impl Job for Raw2DngJob {
         duration: now.elapsed().as_secs_f32(),
         error: Some(e),
       },
-      Err(err) => JobResult {
+      Err(e) => JobResult {
         job: self.clone(),
         duration: now.elapsed().as_secs_f32(),
-        error: Some(AppError::General(format!("Rayon worker panicked before completing: {err}"))),
+        error: Some(AppError::General(format!("Conversion worker failed to join: {e}"))),
       },
     }
   }

--- a/rawler/data/lenses/rf_mount/canon.toml
+++ b/rawler/data/lenses/rf_mount/canon.toml
@@ -320,6 +320,26 @@ aperture_range = [[63, 10], [9, 1]]
 
 [[lenses]]
 mount = "rf-mount"
+key = "RF200-800mm F6.3-9 IS USM + EXTENDER RF1.4x"
+lens_id = 61182
+lens_subid = 310
+make = "Canon"
+model = "RF 200-800mm F6.3-9 IS USM + RF1.4x"
+focal_range = [[280, 1], [1120, 1]]
+aperture_range = [[9, 1], [13, 1]]
+
+[[lenses]]
+mount = "rf-mount"
+key = "RF200-800mm F6.3-9 IS USM + EXTENDER RF2x"
+lens_id = 61182
+lens_subid = 311
+make = "Canon"
+model = "RF 200-800mm F6.3-9 IS USM + RF2x"
+focal_range = [[400, 1], [1600, 1]]
+aperture_range = [[13, 1], [18, 1]]
+
+[[lenses]]
+mount = "rf-mount"
 key = "RF-S10-18mm F4.5-6.3 IS STM"
 lens_id = 61182
 lens_subid = 315

--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -416,36 +416,82 @@ impl<'a> Decoder for Cr3Decoder<'a> {
     Ok(img)
   }
 
-  /// Extract preview image embedded in CR3
-  fn preview_image(&self, file: &RawSource, params: &RawDecodeParams) -> Result<Option<DynamicImage>> {
-    if params.image_index != 0 {
-      return Ok(None);
-    }
+  /// Extract the original JPEG preview bytes embedded in CR3.
+  fn preview_jpeg(&self, file: &RawSource, params: &RawDecodeParams) -> Result<Option<Vec<u8>>> {
     if rawler_ignore_previews() {
       return Err(RawlerError::DecoderFailed("Unable to extract preview image".into()));
     }
-    let offset = self.bmff.filebox.moov.traks[0]
+
+    let sample_idx = params.image_index;
+
+    // Canon CR3 stores the large JPEG preview in the PreviewBig track
+    // described by CCTP/CCDT. Multi-image camera rolls contain preview
+    // samples in the same order as their RAW samples.
+    let preview_trak_id = self.get_trak_index(Cr3ImageType::PreviewBig).unwrap_or(0);
+    let preview_trak = self
+      .moov_trak(preview_trak_id)
+      .ok_or_else(|| RawlerError::DecoderFailed(format!("Unable to get preview trak {}", preview_trak_id)))?;
+
+    let preview_count = preview_trak.mdia.minf.stbl.stsz.sample_count as usize;
+    if sample_idx >= preview_count {
+      warn!(
+        "CR3 preview sample index {} out of range for trak {} ({} samples)",
+        sample_idx, preview_trak_id, preview_count
+      );
+      return Ok(None);
+    }
+
+    // BMFF sample numbers are 1-based. get_sample_offset() resolves stsc,
+    // co64 and stsz, including files with multiple samples in one chunk.
+    let (offset, size) = preview_trak
       .mdia
       .minf
       .stbl
-      .co64
-      .as_ref()
-      .ok_or_else(|| RawlerError::DecoderFailed("co64 box not found".into()))?
-      .entries[0] as usize;
-    let size = self.bmff.filebox.moov.traks[0].mdia.minf.stbl.stsz.sample_sizes[0] as usize;
-    debug!("JPEG preview mdat offset: {}, len: {}", offset, size);
+      .get_sample_offset(sample_idx as u32 + 1)
+      .ok_or_else(|| {
+        RawlerError::DecoderFailed(format!(
+          "CR3 preview sample {} not found in trak {}",
+          sample_idx, preview_trak_id
+        ))
+      })?;
+
+    debug!(
+      "JPEG preview trak: {}, sample_idx: {}, mdat offset: {}, len: {}",
+      preview_trak_id, sample_idx, offset, size
+    );
+
     let buf = file
       .subview(offset as u64, size as u64)
       .map_err(|e| RawlerError::with_io_error("CR3: failed to read full image data", file.path(), e))?;
-    match image::load_from_memory_with_format(buf, image::ImageFormat::Jpeg) {
-      Ok(img) => Ok(Some(img)),
-      Err(e) => {
-        warn!("TRAK 0 contains no JPEG preview, is it PQ/HEIF? Error: {}", e);
-        //Err(RawlerError::DecoderFailed(
-        //  "Unable to extract preview image from CR3 HDR-PQ file. Please see 'https://github.com/dnglab/dnglab/issues/7'".into(),
-        //))
-        Ok(None)
-      }
+
+    // HDR-PQ CR3 files may store HEIF rather than JPEG in this track. Don't
+    // claim those bytes are JPEG; retain the normal RAW-developed fallback.
+    if !buf.starts_with(&[0xff, 0xd8]) {
+      warn!(
+        "CR3 preview trak {} sample {} is not JPEG, is it PQ/HEIF?",
+        preview_trak_id, sample_idx
+      );
+      return Ok(None);
+    }
+
+    Ok(Some(buf.to_vec()))
+  }
+
+  /// Extract and decode the preview image embedded in CR3.
+  ///
+  /// Pixel-oriented callers retain the existing DynamicImage API, while DNG
+  /// conversion can use preview_jpeg() above to avoid this decode entirely.
+  fn preview_image(&self, file: &RawSource, params: &RawDecodeParams) -> Result<Option<DynamicImage>> {
+    let sample_idx = params.image_index;
+    match self.preview_jpeg(file, params)? {
+      Some(buf) => match image::load_from_memory_with_format(&buf, image::ImageFormat::Jpeg) {
+        Ok(img) => Ok(Some(img)),
+        Err(e) => {
+          warn!("CR3 preview sample {} failed to decode as JPEG: {}", sample_idx, e);
+          Ok(None)
+        }
+      },
+      None => Ok(None),
     }
   }
 

--- a/rawler/src/decoders/mod.rs
+++ b/rawler/src/decoders/mod.rs
@@ -353,6 +353,15 @@ pub trait Decoder: Send {
     Ok(None)
   }
 
+  /// Return an already-encoded JPEG preview when the source format stores one.
+  ///
+  /// This lets DNG conversion preserve an embedded JPEG bit-for-bit instead of
+  /// decoding, resizing and re-encoding it. Decoders that don't expose an
+  /// encoded JPEG can keep the default implementation.
+  fn preview_jpeg(&self, _file: &RawSource, _params: &RawDecodeParams) -> Result<Option<Vec<u8>>> {
+    Ok(None)
+  }
+
   fn preview_image(&self, _file: &RawSource, _params: &RawDecodeParams) -> Result<Option<DynamicImage>> {
     info!("Decoder has no preview image support");
     Ok(None)

--- a/rawler/src/dng/convert.rs
+++ b/rawler/src/dng/convert.rs
@@ -245,11 +245,37 @@ where
   }
   raw.finalize()?;
 
-  // Write preview and thumbnail if requested
-  if params.preview || params.thumbnail {
+  // Write preview and thumbnail if requested.
+  //
+  // Prefer an already-encoded JPEG supplied by the decoder. This preserves
+  // camera-embedded previews bit-for-bit and avoids JPEG decode/resize/re-encode.
+  let mut preview_written = false;
+
+  if params.preview {
+    match decoder.preview_jpeg(rawfile, &raw_params) {
+      Ok(Some(jpeg)) => {
+        let mut preview = dng.subframe(1);
+        preview.preview_jpeg(&jpeg)?;
+        preview.finalize()?;
+        preview_written = true;
+      }
+      Ok(None) => {}
+      Err(err) => {
+        log::warn!(
+          "Failed to get encoded preview, falling back to decoded preview: {:?}",
+          err
+        );
+      }
+    }
+  }
+
+  // Keep the existing DynamicImage path for formats without an encoded JPEG,
+  // invalid/non-JPEG CR3 previews (for example HDR-PQ/HEIF), and thumbnail
+  // generation, which requires pixels.
+  if (params.preview && !preview_written) || params.thumbnail {
     match generate_preview(rawfile, decoder.as_ref(), &rawimage, &raw_params) {
       Ok(image) => {
-        if params.preview {
+        if params.preview && !preview_written {
           let mut preview = dng.subframe(1);
           preview.preview(&image, PREVIEW_JPEG_QUALITY)?;
           preview.finalize()?;

--- a/rawler/src/dng/writer.rs
+++ b/rawler/src/dng/writer.rs
@@ -315,6 +315,43 @@ where
     Ok(())
   }
 
+  /// Write an already-encoded JPEG directly as a DNG preview.
+  ///
+  /// Only the JPEG header is parsed to obtain dimensions. The compressed
+  /// payload itself is copied unchanged into the DNG.
+  pub fn preview_jpeg(&mut self, jpeg: &[u8]) -> Result<()> {
+    let (width, height) = image::ImageReader::with_format(
+      std::io::Cursor::new(jpeg),
+      image::ImageFormat::Jpeg,
+    )
+    .into_dimensions()
+    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to read JPEG preview dimensions: {err}")))?;
+
+    let jpeg_len = u32::try_from(jpeg.len())
+      .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "JPEG preview is larger than 4 GiB"))?;
+
+    self.ifd_mut().add_tag(TiffCommonTag::ImageWidth, Value::long(width));
+    self.ifd_mut().add_tag(TiffCommonTag::ImageLength, Value::long(height));
+    self.ifd_mut().add_tag(TiffCommonTag::Compression, CompressionMethod::ModernJPEG);
+    self.ifd_mut().add_tag(TiffCommonTag::BitsPerSample, [8_u16, 8, 8]);
+    self.ifd_mut().add_tag(TiffCommonTag::SampleFormat, [1_u16, 1, 1]);
+    self.ifd_mut().add_tag(TiffCommonTag::PhotometricInt, PhotometricInterpretation::YCbCr);
+    self.ifd_mut().add_tag(TiffCommonTag::RowsPerStrip, Value::long(height));
+    self.ifd_mut().add_tag(TiffCommonTag::SamplesPerPixel, 3_u16);
+    self.ifd_mut().add_tag(DngTag::PreviewColorSpace, PreviewColorSpace::SRgb);
+
+    let offset = self.writer.dng.write_data(jpeg)?;
+    self.ifd_mut().add_value(TiffCommonTag::StripOffsets, Value::Long(vec![offset]));
+    self.ifd_mut().add_tag(TiffCommonTag::StripByteCounts, Value::Long(vec![jpeg_len]));
+
+    debug!(
+      "copied encoded JPEG preview directly: {}x{}, {} bytes",
+      width, height, jpeg_len
+    );
+
+    Ok(())
+  }
+
   pub fn preview(&mut self, img: &DynamicImage, quality: f32) -> Result<()> {
     let now = Instant::now();
     let preview_img = if img.width() > 1024 {


### PR DESCRIPTION
Fixes up various issues I encountered while trying to process and manipulate CR3 files from my R7.
Removes certain parallelism that leads to a panic that results in conversion failure with camera roll files.
Fixes behavior with regard to the Canon RF 200-800mm F6.3-F9 metadata being incorrect when used with the 1.4x and 2x teleconverters.
Fixes camera roll behavior with regard to generating incorrect preview images (now is super fast and uses the built in previews for each camera roll frame). This super fast preview generation still falls back to raw processing if an embedded preview jpeg is missing.
Let me know if you see any issues with this PR.