### PR TITLE
dnglab: serialize conversion jobs for the same input file

### DIFF
--- a/bin/dnglab/dnglab-lib/src/convert.rs
+++ b/bin/dnglab/dnglab-lib/src/convert.rs
@@ -4,7 +4,7 @@
 use clap::ArgMatches;
 use futures::future::join_all;
 use rawler::decoders::supported_extensions;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 
@@ -63,8 +63,29 @@ pub async fn convert(options: &ArgMatches) -> crate::Result<()> {
   let concurrency = resolve_concurrency(options.get_one::<usize>("jobs").copied().unwrap_or(0));
 
   let mut results: Vec<JobResult> = Vec::new();
-  for chunks in jobs.chunks(concurrency) {
-    let mut temp: Vec<JobResult> = join_all(chunks.iter().map(|j| j.execute()))
+
+  // `--image-index all` expands one multi-image RAW into multiple jobs which
+  // all read the same source file. Do not execute two jobs for the same input
+  // concurrently. Jobs for different source files may still run concurrently
+  // up to `concurrency`, so directory/batch conversions retain outer
+  // parallelism.
+  let mut pending: VecDeque<Raw2DngJob> = jobs.into();
+  while !pending.is_empty() {
+    let mut batch: Vec<Raw2DngJob> = Vec::with_capacity(concurrency);
+    let mut deferred: VecDeque<Raw2DngJob> = VecDeque::new();
+    let mut active_inputs: HashSet<PathBuf> = HashSet::new();
+
+    while let Some(job) = pending.pop_front() {
+      if batch.len() < concurrency && active_inputs.insert(job.input.clone()) {
+        batch.push(job);
+      } else {
+        deferred.push_back(job);
+      }
+    }
+    pending = deferred;
+    debug_assert!(!batch.is_empty());
+
+    let mut temp: Vec<JobResult> = join_all(batch.iter().map(|j| j.execute()))
       .await
       .into_iter()
       .map(|res| {


### PR DESCRIPTION
## Summary

`--image-index all` expands a multi-image RAW into one conversion job per image index. Those jobs can currently be scheduled concurrently even though they all read the same source file.

This change serializes jobs that reference the same input path while preserving outer concurrency for different RAW files.

## Why

For multi-image RAW/CR3 files, multiple concurrently active jobs for the same source can create unnecessary contention and can expose decoder/runtime behavior that does not occur when frames are processed serially.

Directory conversions still retain parallelism: one job per distinct source can run in each batch up to the configured `--jobs` limit.

## Implementation

The scheduler now:

- places pending jobs in a `VecDeque`;
- builds each execution batch with unique input paths;
- defers additional jobs for an already-active input to the next batch;
- keeps the existing configured outer concurrency for distinct source files.

No decoder or DNG writer behavior is changed.

## Testing

Tested with a multi-image Canon CR3 camera roll using `--image-index all`, as well as normal single-image conversions.
