### PR TITLE
rawler: select the matching CR3 preview sample for each image index

### DIFF
--- a/rawler/src/decoders/cr3.rs
+++ b/rawler/src/decoders/cr3.rs
@@ -418,32 +418,48 @@ impl<'a> Decoder for Cr3Decoder<'a> {
 
   /// Extract preview image embedded in CR3
   fn preview_image(&self, file: &RawSource, params: &RawDecodeParams) -> Result<Option<DynamicImage>> {
-    if params.image_index != 0 {
-      return Ok(None);
-    }
     if rawler_ignore_previews() {
       return Err(RawlerError::DecoderFailed("Unable to extract preview image".into()));
     }
-    let offset = self.bmff.filebox.moov.traks[0]
+
+    let sample_idx = params.image_index;
+    let preview_trak_id = self.get_trak_index(Cr3ImageType::PreviewBig).unwrap_or(0);
+    let preview_trak = self
+      .moov_trak(preview_trak_id)
+      .ok_or_else(|| RawlerError::DecoderFailed(format!("Unable to get preview trak {}", preview_trak_id)))?;
+
+    let preview_count = preview_trak.mdia.minf.stbl.stsz.sample_count as usize;
+    if sample_idx >= preview_count {
+      warn!(
+        "CR3 preview sample index {} out of range for trak {} ({} samples)",
+        sample_idx, preview_trak_id, preview_count
+      );
+      return Ok(None);
+    }
+
+    let (offset, size) = preview_trak
       .mdia
       .minf
       .stbl
-      .co64
-      .as_ref()
-      .ok_or_else(|| RawlerError::DecoderFailed("co64 box not found".into()))?
-      .entries[0] as usize;
-    let size = self.bmff.filebox.moov.traks[0].mdia.minf.stbl.stsz.sample_sizes[0] as usize;
-    debug!("JPEG preview mdat offset: {}, len: {}", offset, size);
+      .get_sample_offset(sample_idx as u32 + 1)
+      .ok_or_else(|| RawlerError::DecoderFailed(format!("CR3 preview sample {} not found in trak {}", sample_idx, preview_trak_id)))?;
+
+    debug!(
+      "JPEG preview trak: {}, sample_idx: {}, mdat offset: {}, len: {}",
+      preview_trak_id, sample_idx, offset, size
+    );
+
     let buf = file
       .subview(offset as u64, size as u64)
       .map_err(|e| RawlerError::with_io_error("CR3: failed to read full image data", file.path(), e))?;
+
     match image::load_from_memory_with_format(buf, image::ImageFormat::Jpeg) {
       Ok(img) => Ok(Some(img)),
       Err(e) => {
-        warn!("TRAK 0 contains no JPEG preview, is it PQ/HEIF? Error: {}", e);
-        //Err(RawlerError::DecoderFailed(
-        //  "Unable to extract preview image from CR3 HDR-PQ file. Please see 'https://github.com/dnglab/dnglab/issues/7'".into(),
-        //))
+        warn!(
+          "CR3 preview trak {} sample {} contains no JPEG preview, is it PQ/HEIF? Error: {}",
+          preview_trak_id, sample_idx, e
+        );
         Ok(None)
       }
     }


### PR DESCRIPTION
## Summary

Fix embedded preview selection for multi-image Canon CR3 files.

CR3 camera-roll files can contain multiple RAW samples. The current preview path returns `None` for every `image_index != 0` and then hard-codes track 0/sample 0 for index 0.

This change resolves Canon's `PreviewBig` track and selects the preview sample corresponding to the requested RAW image index.

## Existing behavior

For a camera roll with image indexes 0..18:

- index 0 obtains an embedded JPEG preview;
- indexes 1..18 return no embedded preview;
- DNG conversion falls back to developing the RAW to generate those previews.

## New behavior

The preview path now:

- resolves the `PreviewBig` track through the CR3 descriptor;
- selects sample `image_index + 1`;
- uses `get_sample_offset()` so STSC/CO64/STSZ sample mapping is respected;
- validates the preview sample count before reading.

This matches the sample indexing already used by the RAW and CTMD paths.

## Testing

Validated with a Canon CR3 camera roll containing 19 RAW images.

All 19 image indexes obtained the corresponding embedded JPEG preview, and there were no `Preview image not found, try to generate sRGB from RAW` fallbacks.

This PR intentionally keeps the existing decoded `DynamicImage` preview interface. Direct encoded-JPEG passthrough is a separate follow-up change.
