### PR TITLE
rawler: fix Canon RF 200-800mm extender metadata

### DIFF
--- a/rawler/data/lenses/rf_mount/canon.toml
+++ b/rawler/data/lenses/rf_mount/canon.toml
@@ -561,21 +561,23 @@ aperture_range = [[28, 10], [28, 10]]
 
 [[lenses]]
 mount = "rf-mount"
+key = "RF200-800mm F6.3-9 IS USM + EXTENDER RF1.4x"
 lens_id = 61182
 lens_subid = 310
 make = "Canon"
 model = "RF 200-800mm F6.3-9 IS USM + RF1.4x"
-focal_range = [[200, 1], [800, 1]]
-aperture_range = [[63, 10], [9, 1]]
+focal_range = [[280, 1], [1120, 1]]
+aperture_range = [[9, 1], [13, 1]]
 
 [[lenses]]
 mount = "rf-mount"
+key = "RF200-800mm F6.3-9 IS USM + EXTENDER RF2x"
 lens_id = 61182
 lens_subid = 311
 make = "Canon"
 model = "RF 200-800mm F6.3-9 IS USM + RF2x"
-focal_range = [[200, 1], [800, 1]]
-aperture_range = [[63, 10], [9, 1]]
+focal_range = [[400, 1], [1600, 1]]
+aperture_range = [[13, 1], [18, 1]]
 
 [[lenses]]
 mount = "rf-mount"


### PR DESCRIPTION
## Summary

Fix the existing Canon RF 200-800mm F6.3-9 IS USM extender records.

The database already contains:

- `61182:310` — RF 200-800mm F6.3-9 IS USM + RF1.4x
- `61182:311` — RF 200-800mm F6.3-9 IS USM + RF2x

## Problems

The two existing extender entries have two issues:

1. They do not have Canon lens-model `key` values, so CR3 exact-name resolution cannot select them.
2. Their focal/aperture ranges still describe the bare 200-800mm F6.3-9 lens.

The latter affects output metadata: when a lens is resolved, `Exif::extend_from_lens()` replaces the source `LensSpecification` with the database `focal_range` and `aperture_range`.

## Changes

RF1.4x (`61182:310`):

- key: `RF200-800mm F6.3-9 IS USM + EXTENDER RF1.4x`
- focal range: `280-1120 mm`
- aperture range: `f/9-f/13`

RF2x (`61182:311`):

- key: `RF200-800mm F6.3-9 IS USM + EXTENDER RF2x`
- focal range: `400-1600 mm`
- aperture range: `f/13-f/18`

This lets Canon CR3 resolve the extender combinations by exact lens name and writes the effective extender-adjusted LensSpecification to the resulting metadata.
