### PR TITLE
Add Hasselblad X2D II 100C camera definition

### DIFF
--- a/SUPPORTED_CAMERAS.md
+++ b/SUPPORTED_CAMERAS.md
@@ -310,8 +310,10 @@
 |Hasselblad                          | Hasselblad H6D-100cMS                   | ✅ Yes | all |  |
 |Hasselblad                          | Hasselblad X1D                          | ✅ Yes | all |  |
 |Hasselblad                          | Hasselblad X2D 100C                     | ✅ Yes | all |  |
+|Hasselblad                          | Hasselblad X2D II 100C                  | ✅ Yes | all |  |
 |Hasselblad                          | X1D II 50C                              | ✅ Yes | all |  |
 |Hasselblad                          | X2D 100C                                | ✅ Yes | all |  |
+|Hasselblad                          | X2D II 100C                             | ✅ Yes | all |  |
 |KODAK                               | DCS460D         FILE VERSION 3          | ✅ Yes | all |  |
 |KODAK                               | EOSDCS1B        FILE VERSION 3          | ✅ Yes | all |  |
 |KODAK                               | EOSDCS3C        FILE VERSION 3          | ✅ Yes | all |  |

--- a/rawler/data/cameras/hasselblad/x2d_ii_100c.toml
+++ b/rawler/data/cameras/hasselblad/x2d_ii_100c.toml
@@ -1,0 +1,17 @@
+make = "Hasselblad"
+model = "X2D II 100C"
+clean_make = "Hasselblad"
+clean_model = "X2D II 100C"
+color_pattern = "RGGB"
+hints = ["uncompressed"]
+
+model_aliases = [["Hasselblad X2D II 100C", "X2D II 100C"]]
+
+# Masked sensor border measured on three 11904x8842 frames. Phocus trims an
+# additional four pixels per side and produces a 11656x8742 active image.
+active_area = [128, 96, 120, 4]
+
+# The X2D II uses the same sensor family as the X2D 100C. Use its matrix until
+# a dedicated spectral measurement is available.
+[cameras.color_matrix]
+D65 = [0.6468, -0.1899, -0.0545, -0.4526, 1.2267, 0.2542, -0.0388, 0.1276, 0.6096]


### PR DESCRIPTION
Adds a dedicated X2D II 100C definition instead of treating it as an X2D 100C alias. The active area was measured on three owned 11904x8842 3FR captures and matches the 11656x8742 framing produced by Phocus. The sensor-family color matrix is retained until a dedicated spectral measurement is available. Validation: cargo fmt --all --check; cargo test -p rawler --lib (66 passed).