### PR TITLE
Honor TIFF compression in Hasselblad FFF files

### DIFF
--- a/rawler/data/cameras/hasselblad/x1d2.toml
+++ b/rawler/data/cameras/hasselblad/x1d2.toml
@@ -7,6 +7,9 @@ clean_model = "X1D II 50C"
 color_pattern = "RGGB"
 hints = ["uncompressed"]
 
+# Phocus-written FFF files include the make in the model string.
+model_aliases = [["Hasselblad X1D II 50C", "X1D II 50C"]]
+
 active_area = [46, 96, 58, 0]
 
 [cameras.color_matrix]

--- a/rawler/src/decoders/tfr.rs
+++ b/rawler/src/decoders/tfr.rs
@@ -68,7 +68,15 @@ impl<'a> Decoder for TfrDecoder<'a> {
 
     let src = file.subview_until_eof(offset as u64)?;
 
-    let image = if self.camera.find_hint("uncompressed") {
+    // A camera's 3FR and a Phocus-written FFF can use different compression.
+    // Prefer the file's tag and retain the camera hint as a compatibility
+    // fallback for files that omit it.
+    let uncompressed = match raw.get_entry(TiffCommonTag::Compression).map(|tag| tag.force_usize(0)) {
+      Some(1) => true,
+      Some(_) => false,
+      None => self.camera.find_hint("uncompressed"),
+    };
+    let image = if uncompressed {
       decompress_16le(src, width, height, dummy)?
     } else {
       self.decode_compressed(src, width, height, dummy)?


### PR DESCRIPTION
Phocus-written FFF files can use LJPEG compression even when the originating camera definition has the uncompressed hint. Read the raw IFD Compression tag when present and fall back to the existing camera hint only when it is absent. Also recognizes the make-prefixed X1D II model string Phocus writes. Verified with an owned X1D II 50C FFF fixture and with cargo test -p rawler --lib (66 passed).